### PR TITLE
Fix missing type annotation in function parameter

### DIFF
--- a/src/server/map.ts
+++ b/src/server/map.ts
@@ -35,7 +35,7 @@ export class Map {
     return this.tiles[this.pos(coords)];
   }
 
-  private getNeighborsCoordsRecurse({ x, y }: Coords, r, tileList: Coords[]): void {
+  private getNeighborsCoordsRecurse({ x, y }: Coords, r: number, tileList: Coords[]): void {
     if (r > 0 && this.getTile({x, y})) {
       tileList.push({x, y});
       for (const coord of getAdjacentCoords({x, y})) {


### PR DESCRIPTION
Refactor `getNeighborsCoordsRecurse` method in `Map` to type-annotate all its parameters.