### PR TITLE
Ranged Combat + Tile/Unit Selection Fixes

### DIFF
--- a/dist/client/camera.js
+++ b/dist/client/camera.js
@@ -248,8 +248,10 @@ class Camera {
                                 else if (world.posIndex({ x, y }) in this.highlightedTiles) {
                                     world.moveUnit(this.selectedUnitPos, { x, y }, this.highlightedTiles, !!tile.unit);
                                 }
+                                else {
+                                    this.deselectUnit(world);
+                                }
                             }
-                            this.deselectUnit(world);
                         }
                         ctx.drawImage(textures['selector'], (-camX + ((x - (width / 2)) * X_TILE_SPACING)) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING))) * zoom, TILE_WIDTH * zoom, TILE_HEIGHT * zoom);
                         if (tile.unit && this.mouseDownTime === 1 && tile.unit.civID === world.player.civID && ui.turnActive) {

--- a/dist/client/camera.js
+++ b/dist/client/camera.js
@@ -241,7 +241,13 @@ class Camera {
                             world.on.event.selectTile({ x, y }, tile);
                             console.log(x, y);
                             if (this.selectedUnitPos && world.posIndex({ x, y }) in this.highlightedTiles) {
-                                world.moveUnit(this.selectedUnitPos, { x, y }, this.highlightedTiles, !!tile.unit);
+                                const selectedUnit = world.getTile(this.selectedUnitPos).unit;
+                                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED) {
+                                    world.attack(this.selectedUnitPos, { x, y }, this.highlightedTiles, selectedUnit);
+                                }
+                                else {
+                                    world.moveUnit(this.selectedUnitPos, { x, y }, this.highlightedTiles, !!tile.unit);
+                                }
                             }
                             this.deselectUnit(world);
                         }

--- a/dist/client/camera.js
+++ b/dist/client/camera.js
@@ -242,7 +242,7 @@ class Camera {
                             console.log(x, y);
                             if (this.selectedUnitPos) {
                                 const selectedUnit = world.getTile(this.selectedUnitPos).unit;
-                                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED) {
+                                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && tile.unit.civID !== world.player.civID) {
                                     world.attack(this.selectedUnitPos, { x, y }, selectedUnit);
                                 }
                                 else if (world.posIndex({ x, y }) in this.highlightedTiles) {

--- a/dist/client/camera.js
+++ b/dist/client/camera.js
@@ -240,12 +240,12 @@ class Camera {
                             mapClicked = true;
                             world.on.event.selectTile({ x, y }, tile);
                             console.log(x, y);
-                            if (this.selectedUnitPos && world.posIndex({ x, y }) in this.highlightedTiles) {
+                            if (this.selectedUnitPos) {
                                 const selectedUnit = world.getTile(this.selectedUnitPos).unit;
                                 if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED) {
-                                    world.attack(this.selectedUnitPos, { x, y }, this.highlightedTiles, selectedUnit);
+                                    world.attack(this.selectedUnitPos, { x, y }, selectedUnit);
                                 }
-                                else {
+                                else if (world.posIndex({ x, y }) in this.highlightedTiles) {
                                     world.moveUnit(this.selectedUnitPos, { x, y }, this.highlightedTiles, !!tile.unit);
                                 }
                             }

--- a/dist/client/locales/en.json
+++ b/dist/client/locales/en.json
@@ -78,6 +78,10 @@
     "info": {
       "hp": "HP",
       "movement": "Movement"
+    },
+    "action": {
+      "settleCity": "Settle City",
+      "build": "Build"
     }
   },
   "tile": {

--- a/dist/client/player.js
+++ b/dist/client/player.js
@@ -8,6 +8,9 @@ const unitActionsTable = {
     'settler': ['settleCity'],
     'scout': [],
     'builder': ['build'],
+    'warrior': [],
+    'slinger': [],
+    'archer': [],
 };
 const unitActionsFnTable = {
     'settleCity': (pos) => {

--- a/dist/client/player.js
+++ b/dist/client/player.js
@@ -7,7 +7,7 @@ const errandTypeTable = {
 const unitActionsTable = {
     'settler': ['settleCity'],
     'scout': [],
-    'builder': ['buildFarm', 'buildEncampment'],
+    'builder': ['build'],
 };
 const unitActionsFnTable = {
     'settleCity': (pos) => {
@@ -15,25 +15,14 @@ const unitActionsFnTable = {
         const name = prompt(`${translate('menu.city.prompt')}:`);
         return ['settleCity', [pos, name]];
     },
-    'buildFarm': (pos) => {
-        return ['buildImprovement', [pos, 'farm']];
-    },
-    'buildEncampment': (pos) => {
-        return ['buildImprovement', [pos, 'encampment']];
+    'build': (pos, improvement) => {
+        return ['buildImprovement', [pos, improvement]];
     },
 };
 const unitActionsAvailabilityTable = {
     'settleCity': (world, pos) => {
         const tile = world.getTile(pos);
         return world.canSettleOn(tile);
-    },
-    'buildFarm': (world, pos) => {
-        const tile = world.getTile(pos);
-        return world.canBuildOn(tile) && world.canFarmOn(tile);
-    },
-    'buildEncampment': (world, pos) => {
-        const tile = world.getTile(pos);
-        return world.canBuildOn(tile) && !world.isRiver(tile);
     },
 };
 const iconPathTable = {
@@ -340,11 +329,29 @@ class UI {
     }
     showUnitActionsMenu(world, pos, unit) {
         for (const action of unitActionsTable[unit.type]) {
+            if (action === 'build') {
+                world.sendActions([['getImprovementCatalog', [pos]]]);
+                world.on.update.improvementCatalog = (catalogPos, catalog) => {
+                    if (!(pos.x === catalogPos.x && pos.y === catalogPos.y))
+                        return;
+                    for (const item of catalog) {
+                        const actionBtn = new Button(this.createElement('button'), {
+                            // Note that we have the cost info here, we are for now choosing not to display it.
+                            text: `${translate(`unit.action.${action}`)} ${translate(`improvement.${item.type}`)}`,
+                        });
+                        actionBtn.bindCallback(() => {
+                            world.sendActions([unitActionsFnTable[action](pos, item.type)]);
+                        });
+                        this.elements.unitActionsMenu.appendChild(actionBtn.element);
+                    }
+                };
+                continue;
+            }
             if (!unitActionsAvailabilityTable[action](world, pos)) {
                 continue;
             }
             const actionBtn = new Button(this.createElement('button'), {
-                text: action,
+                text: translate(`unit.action.${action}`),
             });
             actionBtn.bindCallback(() => {
                 world.sendActions([unitActionsFnTable[action](pos)]);

--- a/dist/client/style.css
+++ b/dist/client/style.css
@@ -139,6 +139,16 @@ canvas {
   padding: 10px;
 }
 
+.builderActionsMenu {
+	grid-column: 6 / 7;
+	grid-row: 6;
+  background-color: lightgray;
+  border: 2px solid black;
+  border-right: none;
+  border-left: none;
+  padding: 10px;
+}
+
 .unitInfoMenu {
 	grid-column: 7 / 10;
 	grid-row: 6;

--- a/dist/client/style.css
+++ b/dist/client/style.css
@@ -139,16 +139,6 @@ canvas {
   padding: 10px;
 }
 
-.builderActionsMenu {
-	grid-column: 6 / 7;
-	grid-row: 6;
-  background-color: lightgray;
-  border: 2px solid black;
-  border-right: none;
-  border-left: none;
-  padding: 10px;
-}
-
 .unitInfoMenu {
 	grid-column: 7 / 10;
 	grid-row: 6;

--- a/dist/client/world.js
+++ b/dist/client/world.js
@@ -464,7 +464,7 @@ class World {
             this.on.event.selectTile = (coords, tile) => {
                 this.selectedPos = coords;
                 ui.showTileInfoMenu(this, coords, tile);
-                if (tile.improvement) {
+                if (tile.improvement && !tile.improvement.isNatural) {
                     this.fetchImprovementCatalogs(tile.improvement, coords);
                     ui.showSidebarMenu(this, coords, tile);
                 }

--- a/dist/client/world.js
+++ b/dist/client/world.js
@@ -144,10 +144,9 @@ class World {
         path.reverse();
         return path;
     }
-    attack(srcPos, dstPos, pathMap, attacker) {
-        const path = this.findPath(srcPos, dstPos, pathMap);
-        // TODO - this is NOT robust!
-        if (path.length <= attacker.attackRange) {
+    attack(srcPos, dstPos, attacker) {
+        const reachableTiles = this.getTilesInRange(srcPos, attacker.attackRange);
+        if (Object.keys(reachableTiles).includes(this.posIndex(dstPos).toString())) {
             this.sendActions([
                 ['attack', [srcPos, dstPos]]
             ]);

--- a/dist/client/world.js
+++ b/dist/client/world.js
@@ -115,6 +115,9 @@ class World {
         };
         return farmableTiles[tile.type];
     }
+    areSameCoords(pos1, pos2) {
+        return pos1.x === pos2.x && pos1.y === pos2.y;
+    }
     // mode: 0 = land unit, 1 = sea unit; -1 = air unit
     getTilesInRange(srcPos, range, mode = 0) {
         // BFS to find all tiles within `range` steps

--- a/dist/client/world.js
+++ b/dist/client/world.js
@@ -21,6 +21,14 @@ var ErrandType;
     ErrandType[ErrandType["RESEARCH"] = 2] = "RESEARCH";
     // CULTURE,
 })(ErrandType || (ErrandType = {}));
+const canTrainUnits = {
+    'settlement': true,
+    'encampment': true,
+};
+const canResearch = {
+    'settlement': true,
+    'campus': true,
+};
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class World {
     constructor() {
@@ -184,12 +192,10 @@ class World {
         return null;
     }
     fetchImprovementCatalogs(improvement, coords) {
-        if (improvement.type === 'encampment') {
-            // change this check later, to be more general
+        if (canTrainUnits[improvement.type]) {
             this.sendActions([['getUnitCatalog', [coords]]]);
         }
-        else if (improvement.type === 'campus') {
-            // change this check later, to be more general
+        if (canResearch[improvement.type]) {
             this.sendActions([['getKnowledgeCatalog', [coords]]]);
         }
     }

--- a/dist/client/world.js
+++ b/dist/client/world.js
@@ -146,6 +146,7 @@ class World {
     }
     attack(srcPos, dstPos, pathMap, attacker) {
         const path = this.findPath(srcPos, dstPos, pathMap);
+        // TODO - this is NOT robust!
         if (path.length <= attacker.attackRange) {
             this.sendActions([
                 ['attack', [srcPos, dstPos]]

--- a/dist/client/world.js
+++ b/dist/client/world.js
@@ -7,6 +7,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var PromotionClass;
+(function (PromotionClass) {
+    PromotionClass[PromotionClass["CIVILLIAN"] = 0] = "CIVILLIAN";
+    PromotionClass[PromotionClass["MELEE"] = 1] = "MELEE";
+    PromotionClass[PromotionClass["RANGED"] = 2] = "RANGED";
+    PromotionClass[PromotionClass["RECON"] = 3] = "RECON";
+})(PromotionClass || (PromotionClass = {}));
 var ErrandType;
 (function (ErrandType) {
     ErrandType[ErrandType["CONSTRUCTION"] = 0] = "CONSTRUCTION";
@@ -126,8 +133,7 @@ class World {
         }
         return paths;
     }
-    moveUnit(srcPos, dstPos, pathMap, attack) {
-        console.log(srcPos, dstPos, pathMap);
+    findPath(srcPos, dstPos, pathMap) {
         let curPos = dstPos;
         const path = [];
         while (this.posIndex(srcPos) !== this.posIndex(curPos)) {
@@ -136,6 +142,19 @@ class World {
             curPos = pathMap[this.posIndex(curPos)];
         }
         path.reverse();
+        return path;
+    }
+    attack(srcPos, dstPos, pathMap, attacker) {
+        const path = this.findPath(srcPos, dstPos, pathMap);
+        if (path.length <= attacker.attackRange) {
+            this.sendActions([
+                ['attack', [srcPos, dstPos]]
+            ]);
+        }
+    }
+    moveUnit(srcPos, dstPos, pathMap, attack) {
+        console.log(srcPos, dstPos, pathMap);
+        const path = this.findPath(srcPos, dstPos, pathMap);
         this.sendActions([
             ['moveUnit', [srcPos, path, attack]]
         ]);

--- a/dist/client/world.js
+++ b/dist/client/world.js
@@ -116,6 +116,8 @@ class World {
         return farmableTiles[tile.type];
     }
     areSameCoords(pos1, pos2) {
+        if (pos1 === null || pos2 === null)
+            return false;
         return pos1.x === pos2.x && pos1.y === pos2.y;
     }
     // mode: 0 = land unit, 1 = sea unit; -1 = air unit
@@ -383,7 +385,6 @@ class World {
                 this.unusedUnits = unitPositions.map((_, index) => index);
             };
             this.on.update.unitPositionUpdate = (startPos, endPos) => {
-                var _a, _b;
                 const index = this.getUnitIndex(startPos);
                 if (index !== null) {
                     this.unitPositions[index] = endPos;
@@ -391,7 +392,7 @@ class World {
                     if (unit && unit.movement === 0) {
                         this.unusedUnits.splice(this.unusedUnits.indexOf(index), 1);
                     }
-                    if (((_a = camera.selectedUnitPos) === null || _a === void 0 ? void 0 : _a.x) === startPos.x && ((_b = camera.selectedUnitPos) === null || _b === void 0 ? void 0 : _b.y) === startPos.y) {
+                    if (this.areSameCoords(camera.selectedUnitPos, startPos)) {
                         camera.deselectUnit(this);
                         if (unit.movement > 0) {
                             camera.selectUnit(this, endPos, unit);

--- a/dist/client/world.js
+++ b/dist/client/world.js
@@ -368,7 +368,7 @@ class World {
             this.on.update.tileUpdate = (pos, tile) => {
                 this.tiles[this.posIndex(pos)] = tile;
                 if (this.selectedPos && pos.x === this.selectedPos.x && pos.y === this.selectedPos.y) {
-                    if (tile.improvement) {
+                    if (tile.improvement && !tile.improvement.isNatural) {
                         ui.hideSidebarMenu();
                         ui.showSidebarMenu(this, pos, tile);
                         this.fetchImprovementCatalogs(tile.improvement, pos);

--- a/dist/client/world.js
+++ b/dist/client/world.js
@@ -380,12 +380,19 @@ class World {
                 this.unusedUnits = unitPositions.map((_, index) => index);
             };
             this.on.update.unitPositionUpdate = (startPos, endPos) => {
+                var _a, _b;
                 const index = this.getUnitIndex(startPos);
                 if (index !== null) {
                     this.unitPositions[index] = endPos;
                     const unit = this.getTile(endPos).unit;
                     if (unit && unit.movement === 0) {
                         this.unusedUnits.splice(this.unusedUnits.indexOf(index), 1);
+                    }
+                    if (((_a = camera.selectedUnitPos) === null || _a === void 0 ? void 0 : _a.x) === startPos.x && ((_b = camera.selectedUnitPos) === null || _b === void 0 ? void 0 : _b.y) === startPos.y) {
+                        camera.deselectUnit(this);
+                        if (unit.movement > 0) {
+                            camera.selectUnit(this, endPos, unit);
+                        }
                     }
                 }
             };

--- a/dist/server/game/map/generator/index.js
+++ b/dist/server/game/map/generator/index.js
@@ -42,16 +42,17 @@ class PerlinWorldGenerator {
         this.width = width;
         this.height = height;
         // Elevation Constants - Make these configurable later
-        const SEA_LEVEL = 45;
+        const OCEAN_LEVEL = 45;
         const COAST_LEVEL = 55;
         const PLAINS_LEVEL = 60;
         const HILLS_LEVEL = 80;
         const HIGHLANDS_LEVEL = 90;
         const MOUNTAIN_LEVEL = 98;
+        this.seaLevel = COAST_LEVEL;
         // Define Biomes
         this.biomes = {
             'plains': new biome_1.Biome(this.random, OCEAN, [
-                [SEA_LEVEL, SHALLOW_OCEAN],
+                [OCEAN_LEVEL, SHALLOW_OCEAN],
                 [COAST_LEVEL, GRASS_LOWLANDS],
                 [PLAINS_LEVEL, GRASS_PLAINS],
                 [HILLS_LEVEL, new biome_1.TilePool([[GRASS_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
@@ -59,7 +60,7 @@ class PerlinWorldGenerator {
                 [MOUNTAIN_LEVEL, new biome_1.TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
             ]),
             'temperate_forest': new biome_1.Biome(this.random, OCEAN, [
-                [SEA_LEVEL, SHALLOW_OCEAN],
+                [OCEAN_LEVEL, SHALLOW_OCEAN],
                 [COAST_LEVEL, TEMPERATE_FOREST_LOWLANDS],
                 [PLAINS_LEVEL, TEMPERATE_FOREST_PLAINS],
                 [HILLS_LEVEL, new biome_1.TilePool([[TEMPERATE_FOREST_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
@@ -67,29 +68,29 @@ class PerlinWorldGenerator {
                 [MOUNTAIN_LEVEL, new biome_1.TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
             ]),
             'tundra': new biome_1.Biome(this.random, OCEAN, [
-                [SEA_LEVEL, SHALLOW_OCEAN],
-                [SEA_LEVEL + 5, FROZEN_RIVER],
+                [OCEAN_LEVEL, SHALLOW_OCEAN],
+                [OCEAN_LEVEL + 5, FROZEN_RIVER],
                 [COAST_LEVEL, SNOW_PLAINS],
                 [HILLS_LEVEL, SNOW_HILLS],
                 [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
                 [MOUNTAIN_LEVEL, MOUNTAIN],
             ]),
             'arctic': new biome_1.Biome(this.random, FROZEN_OCEAN, [
-                [SEA_LEVEL, SHALLOW_FROZEN_OCEAN],
+                [OCEAN_LEVEL, SHALLOW_FROZEN_OCEAN],
                 [COAST_LEVEL, SNOW_PLAINS],
                 [HILLS_LEVEL, SNOW_HILLS],
                 [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
                 [MOUNTAIN_LEVEL, MOUNTAIN],
             ]),
             'desert': new biome_1.Biome(this.random, OCEAN, [
-                [SEA_LEVEL, SHALLOW_OCEAN],
+                [OCEAN_LEVEL, SHALLOW_OCEAN],
                 [COAST_LEVEL, DESERT_PLAINS],
                 [HILLS_LEVEL, DESERT_HILLS],
                 [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
                 [MOUNTAIN_LEVEL, new biome_1.TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
             ]),
             'mild_desert': new biome_1.Biome(this.random, OCEAN, [
-                [SEA_LEVEL, SHALLOW_OCEAN],
+                [OCEAN_LEVEL, SHALLOW_OCEAN],
                 [COAST_LEVEL, new biome_1.TilePool([[DESERT_PLAINS, 3], [GRASS_LOWLANDS, 1]])],
                 [PLAINS_LEVEL, DESERT_PLAINS],
                 [HILLS_LEVEL, DESERT_HILLS],
@@ -190,7 +191,7 @@ class PerlinWorldGenerator {
         let i = 0;
         for (let y = 0; y < height; y++) {
             for (let x = 0; x < width; x++) {
-                const tile = new tile_1.Tile(tileTypeMap[i].type, heightMap[i], new yield_1.Yield(tileTypeMap[i].yieldParams));
+                const tile = new tile_1.Tile(tileTypeMap[i].type, Math.max(heightMap[i], this.seaLevel), new yield_1.Yield(tileTypeMap[i].yieldParams));
                 const vegetation = tileTypeMap[i].getVegetation(this.random);
                 if (vegetation)
                     tile.improvement = new improvement_1.Improvement(vegetation, tile.baseYield);

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -121,8 +121,34 @@ class Map {
         }
         return [paths, dst];
     }
+    getVisibleTilesRecurse(coords, maxElevation, r, direction, coordsArray, tileSet, stepsUntilSpread, stepLength) {
+        // const newCoords = getCoordInDirection(coords, direction);
+        const tile = this.getTile(coords);
+        if (r > 0 && tile.getTotalElevation() <= maxElevation + 5) {
+            if (!tileSet.has(tile)) {
+                coordsArray.push(coords);
+                tileSet.add(tile);
+            }
+            if (stepsUntilSpread === 0) {
+                this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(coords, direction - 1), maxElevation, r - 1, direction, coordsArray, tileSet, stepLength, stepLength);
+                this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(coords, direction), maxElevation, r - 1, direction, coordsArray, tileSet, 0, stepLength + 1);
+                this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(coords, direction - 1), maxElevation, r - 1, direction, coordsArray, tileSet, stepLength, stepLength);
+            }
+            else {
+                this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(coords, direction), maxElevation, r - 1, direction, coordsArray, tileSet, stepsUntilSpread - 1, stepLength);
+            }
+        }
+    }
     getVisibleTilesCoords(unit, range) {
-        return [unit.coords, ...this.getNeighborsCoords(unit.coords, range !== null && range !== void 0 ? range : unit.visionRange)];
+        const coordsArray = [];
+        const tileSet = new Set();
+        coordsArray.push(unit.coords);
+        tileSet.add(this.getTile(unit.coords));
+        for (let direction = 0; direction < 6; direction++) {
+            this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(unit.coords, direction), this.getTile(unit.coords).getTotalElevation(), range !== null && range !== void 0 ? range : unit.visionRange, direction, coordsArray, tileSet, 0, 1);
+        }
+        return coordsArray;
+        // return [unit.coords, ...this.getNeighborsCoords(unit.coords, range ?? unit.visionRange)];
     }
     canUnitSee(unit, targetCoords, isAttack = false) {
         var _a;

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -164,14 +164,15 @@ class Map {
         }
         return coordsArray;
     }
-    canUnitSee(unit, targetCoords, isAttack = false) {
-        var _a;
-        const visibleTiles = this.getVisibleTilesCoords(unit, isAttack ? ((_a = unit.attackRange) !== null && _a !== void 0 ? _a : 1) : unit.visionRange);
+    canUnitSee(unit, targetCoords, options) {
+        var _a, _b;
+        const isAttack = (_a = options === null || options === void 0 ? void 0 : options.isAttack) !== null && _a !== void 0 ? _a : false;
+        const visibleTiles = this.getVisibleTilesCoords(unit, isAttack ? ((_b = unit.attackRange) !== null && _b !== void 0 ? _b : 1) : unit.visionRange);
         return (0, utils_1.arrayIncludesCoords)(visibleTiles, targetCoords);
     }
     canUnitAttack(unit, target) {
         if (unit.promotionClass === unit_1.PromotionClass.RANGED) {
-            return this.canUnitSee(unit, target.coords, true);
+            return this.canUnitSee(unit, target.coords, { isAttack: true });
         }
         else {
             return unit.isAdjacentTo(target.coords);

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -163,7 +163,6 @@ class Map {
             this.getVisibleTilesRecurse(newCoords, this.getTile(unit.coords).getTotalElevation() + slope, slope, range !== null && range !== void 0 ? range : unit.visionRange, direction, coordsArray, tileSet, 0, 1);
         }
         return coordsArray;
-        // return [unit.coords, ...this.getNeighborsCoords(unit.coords, range ?? unit.visionRange)];
     }
     canUnitSee(unit, targetCoords, isAttack = false) {
         var _a;

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -121,31 +121,46 @@ class Map {
         }
         return [paths, dst];
     }
-    getVisibleTilesRecurse(coords, maxElevation, r, direction, coordsArray, tileSet, stepsUntilSpread, stepLength) {
-        // const newCoords = getCoordInDirection(coords, direction);
+    getVisibleTilesRecurse(coords, maxElevation, slope, r, direction, coordsArray, tileSet, stepsUntilSpread, stepLength) {
         const tile = this.getTile(coords);
-        if (r > 0 && tile.getTotalElevation() <= maxElevation + 5) {
-            if (!tileSet.has(tile)) {
+        if (r > 0) {
+            if (!tileSet.has(tile) && tile.getTotalElevation() >= maxElevation) {
                 coordsArray.push(coords);
                 tileSet.add(tile);
             }
             if (stepsUntilSpread === 0) {
-                this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(coords, direction - 1), maxElevation, r - 1, direction, coordsArray, tileSet, stepLength, stepLength);
-                this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(coords, direction), maxElevation, r - 1, direction, coordsArray, tileSet, 0, stepLength + 1);
-                this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(coords, direction - 1), maxElevation, r - 1, direction, coordsArray, tileSet, stepLength, stepLength);
+                const newLeftCoords = (0, utils_1.getCoordInDirection)(coords, direction - 1);
+                const newLeftTile = this.getTile(newLeftCoords);
+                const newLeftSlope = newLeftTile.getTotalElevation() - maxElevation;
+                this.getVisibleTilesRecurse(newLeftCoords, maxElevation + slope, Math.max(slope, newLeftSlope), r - 1, direction, coordsArray, tileSet, stepLength, stepLength);
+                const newCoords = (0, utils_1.getCoordInDirection)(coords, direction);
+                const newTile = this.getTile(newCoords);
+                const newSlope = newTile.getTotalElevation() - maxElevation;
+                this.getVisibleTilesRecurse(newCoords, maxElevation + slope, Math.max(slope, newSlope), r - 1, direction, coordsArray, tileSet, stepLength, stepLength);
+                const newRightCoords = (0, utils_1.getCoordInDirection)(coords, direction + 1);
+                const newRightTile = this.getTile(newRightCoords);
+                const newRightSlope = newRightTile.getTotalElevation() - maxElevation;
+                this.getVisibleTilesRecurse(newRightCoords, maxElevation + slope, Math.max(slope, newRightSlope), r - 1, direction, coordsArray, tileSet, stepLength, stepLength);
             }
             else {
-                this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(coords, direction), maxElevation, r - 1, direction, coordsArray, tileSet, stepsUntilSpread - 1, stepLength);
+                const newCoords = (0, utils_1.getCoordInDirection)(coords, direction);
+                const newTile = this.getTile(newCoords);
+                const newSlope = newTile.getTotalElevation() - maxElevation;
+                this.getVisibleTilesRecurse(newCoords, maxElevation + slope, Math.max(slope, newSlope), r - 1, direction, coordsArray, tileSet, stepsUntilSpread - 1, stepLength);
             }
         }
     }
     getVisibleTilesCoords(unit, range) {
         const coordsArray = [];
         const tileSet = new Set();
+        const tile = this.getTile(unit.coords);
         coordsArray.push(unit.coords);
-        tileSet.add(this.getTile(unit.coords));
+        tileSet.add(tile);
         for (let direction = 0; direction < 6; direction++) {
-            this.getVisibleTilesRecurse((0, utils_1.getCoordInDirection)(unit.coords, direction), this.getTile(unit.coords).getTotalElevation(), range !== null && range !== void 0 ? range : unit.visionRange, direction, coordsArray, tileSet, 0, 1);
+            const newCoords = (0, utils_1.getCoordInDirection)(unit.coords, direction);
+            const newTile = this.getTile(newCoords);
+            const slope = newTile.getTotalElevation() - tile.getTotalElevation();
+            this.getVisibleTilesRecurse(newCoords, this.getTile(unit.coords).getTotalElevation() + slope, slope, range !== null && range !== void 0 ? range : unit.visionRange, direction, coordsArray, tileSet, 0, 1);
         }
         return coordsArray;
         // return [unit.coords, ...this.getNeighborsCoords(unit.coords, range ?? unit.visionRange)];

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -121,12 +121,12 @@ class Map {
         }
         return [paths, dst];
     }
-    getVisibleTilesCoords(unit, visionRange = 2) {
-        return [unit.coords, ...this.getNeighborsCoords(unit.coords, visionRange)];
+    getVisibleTilesCoords(unit, range) {
+        return [unit.coords, ...this.getNeighborsCoords(unit.coords, range !== null && range !== void 0 ? range : unit.visionRange)];
     }
     canUnitSee(unit, targetCoords, isAttack = false) {
         var _a;
-        const visibleTiles = this.getVisibleTilesCoords(unit, isAttack ? ((_a = unit.attackRange) !== null && _a !== void 0 ? _a : 1) : 2);
+        const visibleTiles = this.getVisibleTilesCoords(unit, isAttack ? ((_a = unit.attackRange) !== null && _a !== void 0 ? _a : 1) : unit.visionRange);
         return (0, utils_1.arrayIncludesCoords)(visibleTiles, targetCoords);
     }
     canUnitAttack(unit, target) {

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -73,21 +73,27 @@ class Map {
             callback(tile, coords);
         }
     }
-    getNeighborsRecurse(coords, r, tileSet, coordList, filter) {
+    getNeighborsRecurse(coords, r, tileSet, coordList, rangeMap, filter) {
         const tile = this.getTile(coords);
-        if (r >= 0 && tile && !tileSet.has(tile)) {
-            if (!filter || filter(tile, coords)) {
-                tileSet.add(tile);
-                coordList.push(coords);
+        if (r >= 0 && tile) {
+            if (!tileSet.has(tile)) {
+                if (!filter || filter(tile, coords)) {
+                    tileSet.add(tile);
+                    coordList.push(coords);
+                    rangeMap[this.pos(coords)] = r;
+                }
             }
             for (const coord of (0, utils_1.getAdjacentCoords)(coords)) {
-                this.getNeighborsRecurse(coord, r - 1, tileSet, coordList);
+                const pos = this.pos(coord);
+                if (!rangeMap[pos] || rangeMap[pos] < r - 1) {
+                    this.getNeighborsRecurse(coord, r - 1, tileSet, coordList, rangeMap, filter);
+                }
             }
         }
     }
     getNeighborsCoords(coords, r = 1, options) {
         const coordList = [];
-        this.getNeighborsRecurse(coords, r, new Set(), coordList, options === null || options === void 0 ? void 0 : options.filter);
+        this.getNeighborsRecurse(coords, r, new Set(), coordList, {}, options === null || options === void 0 ? void 0 : options.filter);
         return coordList;
     }
     getPathTree(srcPos, range, mode) {
@@ -165,11 +171,21 @@ class Map {
         this.updates.push((civID) => ['tileUpdate', [coords, this.getCivTile(civID, tile)]]);
     }
     moveUnitTo(unit, coords) {
+        // mark tiles currently visible by unit as unseen
+        const srcVisible = this.getVisibleTilesCoords(unit);
+        for (const visibleCoords of srcVisible) {
+            this.setTileVisibility(unit.civID, visibleCoords, false);
+        }
         this.getTile(unit.coords).setUnit(undefined);
         this.tileUpdate(unit.coords);
         unit.coords = coords;
         this.getTile(coords).setUnit(unit);
         this.tileUpdate(coords);
+        // mark tiles now visible by unit as seen
+        const newVisible = this.getVisibleTilesCoords(unit);
+        for (const visibleCoords of newVisible) {
+            this.setTileVisibility(unit.civID, visibleCoords, true);
+        }
     }
     addTrader(trader) {
         this.traders.push(trader);

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -121,8 +121,21 @@ class Map {
         }
         return [paths, dst];
     }
-    getVisibleTilesCoords(unit) {
-        return [unit.coords, ...this.getNeighborsCoords(unit.coords, 2)];
+    getVisibleTilesCoords(unit, visionRange = 2) {
+        return [unit.coords, ...this.getNeighborsCoords(unit.coords, visionRange)];
+    }
+    canUnitSee(unit, targetCoords, isAttack = false) {
+        var _a;
+        const visibleTiles = this.getVisibleTilesCoords(unit, isAttack ? ((_a = unit.attackRange) !== null && _a !== void 0 ? _a : 1) : 2);
+        return (0, utils_1.arrayIncludesCoords)(visibleTiles, targetCoords);
+    }
+    canUnitAttack(unit, target) {
+        if (unit.promotionClass === unit_1.PromotionClass.RANGED) {
+            return this.canUnitSee(unit, target.coords, true);
+        }
+        else {
+            return unit.isAdjacentTo(target.coords);
+        }
     }
     setTileOwner(coords, owner, overwrite) {
         var _a;

--- a/dist/server/game/map/tile/improvement.js
+++ b/dist/server/game/map/tile/improvement.js
@@ -149,6 +149,9 @@ Improvement.storeCapTable = {
 Improvement.naturalImprovementTable = {
     'forest': true,
 };
+Improvement.improvementHeightTable = {
+    'forest': 5,
+};
 Improvement.trainableUnitClassTable = {
     'settlement': [unit_1.PromotionClass.CIVILLIAN],
     'encampment': [unit_1.PromotionClass.MELEE, unit_1.PromotionClass.RANGED, unit_1.PromotionClass.RECON],

--- a/dist/server/game/map/tile/improvement.js
+++ b/dist/server/game/map/tile/improvement.js
@@ -57,6 +57,7 @@ class Improvement {
             pillaged: this.pillaged,
             storage: this.storage,
             errand: (_a = this.errand) === null || _a === void 0 ? void 0 : _a.getData(),
+            isNatural: this.isNatural,
         };
     }
     /**

--- a/dist/server/game/map/tile/improvement.js
+++ b/dist/server/game/map/tile/improvement.js
@@ -24,6 +24,9 @@ class Improvement {
         //   this.yield = new Yield({});
         // }
     }
+    static makeCatalog(types) {
+        return types.map(type => ({ type, cost: errand_1.WorkErrand.errandCostTable[errand_1.ErrandType.CONSTRUCTION][type] }));
+    }
     export() {
         var _a;
         return {

--- a/dist/server/game/map/tile/index.js
+++ b/dist/server/game/map/tile/index.js
@@ -69,6 +69,15 @@ class Tile {
         const mode = unit.getMovementClass();
         return mode > -1 ? this.movementCost[mode] || Infinity : 1;
     }
+    getTotalElevation() {
+        var _a;
+        if (this.improvement) {
+            return (_a = this.elevation + improvement_1.Improvement.improvementHeightTable[this.improvement.type]) !== null && _a !== void 0 ? _a : 0;
+        }
+        else {
+            return this.elevation;
+        }
+    }
     setUnit(unit) {
         this.unit = unit;
     }

--- a/dist/server/game/map/tile/index.js
+++ b/dist/server/game/map/tile/index.js
@@ -141,6 +141,15 @@ class Tile {
     }
     /**
      *
+     * @returns list of improvements the builder on this tile knows how to build
+     */
+    getBuildableImprovements() {
+        if (!(this.unit))
+            return [];
+        return knowledge_1.Knowledge.getBuildableImprovements(this.getKnowledges(true));
+    }
+    /**
+     *
      * @returns list of units classes this improvement knows how to train
      */
     getTrainableUnitTypes() {
@@ -149,6 +158,17 @@ class Tile {
         const trainableUnitClasses = this.improvement.getTrainableUnitClasses().reduce((obj, name) => (Object.assign(Object.assign({}, obj), { [name]: true })), {});
         return knowledge_1.Knowledge.getTrainableUnits(this.getKnowledges(true))
             .filter(unitType => trainableUnitClasses[unit_1.Unit.promotionClassTable[unitType]]);
+    }
+    /**
+     *
+     * @returns type and cost of improvements the builder on this tile knows how to build, or null if it cannot build improvements
+     */
+    getImprovementCatalog() {
+        const buildableImprovements = this.getBuildableImprovements();
+        const catalog = improvement_1.Improvement.makeCatalog(buildableImprovements);
+        if (catalog.length === 0)
+            return null;
+        return catalog;
     }
     /**
      *

--- a/dist/server/game/map/tile/index.js
+++ b/dist/server/game/map/tile/index.js
@@ -152,18 +152,18 @@ class Tile {
      * @returns whether farms can be build on this tile
      */
     isFarmable() {
-        const farmableTiles = {
-            grass_lowlands: true,
-            plains: true,
+        const farmableTileTypes = {
+            'grass_lowlands': true,
+            'plains': true,
         };
-        return farmableTiles[this.type];
+        return this.type in farmableTileTypes;
     }
     /**
      *
      * @returns list of improvements the builder on this tile knows how to build
      */
     getBuildableImprovements() {
-        if (!(this.unit))
+        if (!this.unit)
             return [];
         return knowledge_1.Knowledge.getBuildableImprovements(this.getKnowledges(true))
             .filter((improvementType) => {

--- a/dist/server/game/map/tile/index.js
+++ b/dist/server/game/map/tile/index.js
@@ -69,14 +69,13 @@ class Tile {
         const mode = unit.getMovementClass();
         return mode > -1 ? this.movementCost[mode] || Infinity : 1;
     }
+    /**
+     *
+     * @returns the total elevation of this tile plus the height of any improvemnts on it, rounded to the nearest unit.
+     */
     getTotalElevation() {
         var _a;
-        if (this.improvement) {
-            return (_a = this.elevation + improvement_1.Improvement.improvementHeightTable[this.improvement.type]) !== null && _a !== void 0 ? _a : 0;
-        }
-        else {
-            return this.elevation;
-        }
+        return Math.round(this.elevation + (this.improvement ? (_a = improvement_1.Improvement.improvementHeightTable[this.improvement.type]) !== null && _a !== void 0 ? _a : 0 : 0));
     }
     setUnit(unit) {
         this.unit = unit;

--- a/dist/server/game/map/tile/index.js
+++ b/dist/server/game/map/tile/index.js
@@ -141,12 +141,28 @@ class Tile {
     }
     /**
      *
+     * @returns whether farms can be build on this tile
+     */
+    isFarmable() {
+        const farmableTiles = {
+            grass_lowlands: true,
+            plains: true,
+        };
+        return farmableTiles[this.type];
+    }
+    /**
+     *
      * @returns list of improvements the builder on this tile knows how to build
      */
     getBuildableImprovements() {
         if (!(this.unit))
             return [];
-        return knowledge_1.Knowledge.getBuildableImprovements(this.getKnowledges(true));
+        return knowledge_1.Knowledge.getBuildableImprovements(this.getKnowledges(true))
+            .filter((improvementType) => {
+            if (improvementType === 'farm' && !this.isFarmable())
+                return false;
+            return true;
+        });
     }
     /**
      *

--- a/dist/server/game/map/tile/knowledge.js
+++ b/dist/server/game/map/tile/knowledge.js
@@ -82,6 +82,8 @@ class Knowledge {
 }
 exports.Knowledge = Knowledge;
 Knowledge.knowledgeTree = {
+    'start': new Knowledge('start', KnowledgeBranch.DEVELOPMENT, new yield_1.Yield({ science: 0 }), [], { units: ['settler', 'builder'] }),
+    'food_0': new Knowledge('food_0', KnowledgeBranch.DEVELOPMENT, new yield_1.Yield({ science: 10 }), [], { improvements: ['farm'] }),
     'military_0': new Knowledge('military_0', KnowledgeBranch.OFFENSE, new yield_1.Yield({ science: 10 }), [], { units: ['warrior', 'slinger'] }),
     'recon_0': new Knowledge('recon_0', KnowledgeBranch.OFFENSE, new yield_1.Yield({ science: 10 }), [], { units: ['scout'] }),
     'ranged_1': new Knowledge('ranged_1', KnowledgeBranch.OFFENSE, new yield_1.Yield({ science: 10 }), ['military_0'], { units: ['archer'] }),

--- a/dist/server/game/map/tile/unit.js
+++ b/dist/server/game/map/tile/unit.js
@@ -21,6 +21,7 @@ class Unit {
         this.type = type;
         this.hp = 100;
         this.movement = 0;
+        this.promotionClass = Unit.promotionClassTable[type];
         this.movementClass = Unit.movementClassTable[type];
         this.combatStats = Unit.combatStatsTable[type];
         this.civID = civID;
@@ -35,6 +36,7 @@ class Unit {
             type: this.type,
             hp: this.hp,
             movement: this.movement,
+            promotionClass: this.promotionClass,
             movementClass: this.movementClass,
             combatStats: this.combatStats,
             civID: this.civID,
@@ -46,6 +48,7 @@ class Unit {
         const unit = new Unit(data.type, data.civID, data.coords);
         unit.hp = data.hp;
         unit.movement = data.movement;
+        unit.promotionClass = data.promotionClass;
         unit.movementClass = data.movementClass;
         unit.combatStats = data.combatStats;
         unit.alive = data.alive;

--- a/dist/server/game/map/tile/unit.js
+++ b/dist/server/game/map/tile/unit.js
@@ -24,6 +24,9 @@ class Unit {
         this.promotionClass = Unit.promotionClassTable[type];
         this.movementClass = Unit.movementClassTable[type];
         this.combatStats = Unit.combatStatsTable[type];
+        if (this.promotionClass === PromotionClass.RANGED) {
+            this.attackRange = Unit.attackRangeTable[type];
+        }
         this.civID = civID;
         this.coords = coords;
         this.alive = true;
@@ -36,9 +39,6 @@ class Unit {
             type: this.type,
             hp: this.hp,
             movement: this.movement,
-            promotionClass: this.promotionClass,
-            movementClass: this.movementClass,
-            combatStats: this.combatStats,
             civID: this.civID,
             coords: this.coords,
             alive: this.alive,
@@ -48,9 +48,12 @@ class Unit {
         const unit = new Unit(data.type, data.civID, data.coords);
         unit.hp = data.hp;
         unit.movement = data.movement;
-        unit.promotionClass = data.promotionClass;
-        unit.movementClass = data.movementClass;
-        unit.combatStats = data.combatStats;
+        unit.promotionClass = Unit.promotionClassTable[unit.type];
+        unit.movementClass = Unit.movementClassTable[unit.type];
+        unit.combatStats = Unit.combatStatsTable[unit.type];
+        if (unit.promotionClass === PromotionClass.RANGED) {
+            unit.attackRange = Unit.attackRangeTable[unit.type];
+        }
         unit.alive = data.alive;
         return unit;
     }
@@ -60,6 +63,8 @@ class Unit {
             hp: this.hp,
             movement: this.movement,
             civID: this.civID,
+            promotionClass: this.promotionClass,
+            attackRange: this.attackRange,
         };
     }
     getMovementClass() {
@@ -123,6 +128,10 @@ Unit.combatStatsTable = {
     'slinger': [10, 5, 12],
     'archer': [15, 5, 12],
     'spy': [5, 3, 20],
+};
+Unit.attackRangeTable = {
+    'slinger': 2,
+    'archer': 3,
 };
 Unit.costTable = {
     'settler': new yield_1.Yield({ production: 10 }),

--- a/dist/server/game/map/tile/unit.js
+++ b/dist/server/game/map/tile/unit.js
@@ -18,6 +18,7 @@ var PromotionClass;
 })(PromotionClass = exports.PromotionClass || (exports.PromotionClass = {}));
 class Unit {
     constructor(type, civID, coords) {
+        var _a;
         this.type = type;
         this.hp = 100;
         this.movement = 0;
@@ -27,6 +28,7 @@ class Unit {
         if (this.promotionClass === PromotionClass.RANGED) {
             this.attackRange = Unit.attackRangeTable[type];
         }
+        this.visionRange = (_a = Unit.visionRangeTable[type]) !== null && _a !== void 0 ? _a : Unit.visionRangeTable.default;
         this.civID = civID;
         this.coords = coords;
         this.alive = true;
@@ -132,6 +134,10 @@ Unit.combatStatsTable = {
 Unit.attackRangeTable = {
     'slinger': 2,
     'archer': 3,
+};
+Unit.visionRangeTable = {
+    default: 2,
+    'scout': 3,
 };
 Unit.costTable = {
     'settler': new yield_1.Yield({ production: 10 }),

--- a/dist/server/game/world.js
+++ b/dist/server/game/world.js
@@ -6,6 +6,7 @@ const unit_1 = require("./map/tile/unit");
 const civilization_1 = require("./civilization");
 const random_1 = require("../utils/random");
 const leader_1 = require("./leader");
+const DAMAGE_MULTIPLIER = 20;
 class World {
     constructor(map, civsCount) {
         this.updates = [];
@@ -189,13 +190,39 @@ class World {
         this.updateCivTileVisibility(unit.civID);
         this.updates.push((civID) => ['setMap', [this.map.getCivMap(civID)]]);
     }
+    rangedCombat(attacker, defender) {
+        const [attackerOffense, attackerDefense, attackerAwareness] = attacker.combatStats;
+        const [defenderOffense, defenderDefense, defenderAwareness] = defender.combatStats;
+        const attackerInitiative = Math.random() * (attackerAwareness * 6);
+        const defenderInitiative = Math.random() * (defenderAwareness);
+        const defenderCanAttack = this.map.canUnitAttack(defender, attacker);
+        if (attackerInitiative > defenderInitiative || !defenderCanAttack) {
+            const attackerDamage = (attackerOffense * attacker.hp) / (defenderDefense * defender.hp) * DAMAGE_MULTIPLIER;
+            defender.hurt(attackerDamage);
+            if (defenderCanAttack) {
+                const defenderDamage = (defenderOffense * defender.hp) / (attackerDefense * attacker.hp) * DAMAGE_MULTIPLIER;
+                attacker.hurt(defenderDamage);
+            }
+        }
+        else {
+            const defenderDamage = (defenderOffense * defender.hp) / (attackerDefense * attacker.hp) * DAMAGE_MULTIPLIER;
+            attacker.hurt(defenderDamage);
+            const attackerDamage = (attackerOffense * attacker.hp) / (defenderDefense * defender.hp) * DAMAGE_MULTIPLIER;
+            defender.hurt(attackerDamage);
+        }
+        if (attacker.isDead())
+            this.removeUnit(attacker);
+        if (defender.isDead())
+            this.removeUnit(defender);
+        this.map.tileUpdate(attacker.coords);
+        this.map.tileUpdate(defender.coords);
+    }
     // unit, map, civs
     meleeCombat(attacker, defender) {
         const [attackerOffense, attackerDefense, attackerAwareness] = attacker.combatStats;
         const [defenderOffense, defenderDefense, defenderAwareness] = defender.combatStats;
         const attackerInitiative = Math.random() * (attackerAwareness * 1.5);
         const defenderInitiative = Math.random() * (defenderAwareness);
-        const DAMAGE_MULTIPLIER = 20;
         if (attackerInitiative > defenderInitiative) {
             const attackerDamage = (attackerOffense * attacker.hp) / (defenderDefense * defender.hp) * DAMAGE_MULTIPLIER;
             defender.hurt(attackerDamage);

--- a/dist/server/methods.js
+++ b/dist/server/methods.js
@@ -385,6 +385,28 @@ const methods = {
             }
         }
     },
+    /**
+     * The list of improvements the builder on the given coords is able to build
+     * @param coords
+     */
+    getImprovementCatalog: (ws, coords) => {
+        var _a;
+        const username = getUsername(ws);
+        const gameID = getGameID(ws);
+        const game = exports.games[gameID];
+        const civID = game.players[username].civID;
+        if (game) {
+            const map = game.world.map;
+            const tile = map.getTile(coords);
+            if (((_a = tile.owner) === null || _a === void 0 ? void 0 : _a.civID) === civID && tile.unit) {
+                game.sendToCiv(civID, {
+                    update: [
+                        ['improvementCatalog', [coords, tile.getImprovementCatalog()]],
+                    ],
+                });
+            }
+        }
+    },
     buildImprovement: (ws, coords, type) => {
         const username = getUsername(ws);
         const gameID = getGameID(ws);

--- a/dist/server/methods.js
+++ b/dist/server/methods.js
@@ -305,7 +305,7 @@ const methods = {
                     game.sendUpdates();
                     return;
                 }
-                if (target.unit && map.canUnitAttack(unit, target.unit)) {
+                if (target.unit && map.canUnitAttack(unit, target.unit) && unit.movement > 0) {
                     if (unit.promotionClass === unit_1.PromotionClass.RANGED) {
                         world.rangedCombat(unit, target.unit);
                         unit.movement = 0;

--- a/dist/server/methods.js
+++ b/dist/server/methods.js
@@ -308,18 +308,8 @@ const methods = {
                 if (dst.unit) {
                     break;
                 }
-                // mark tiles currently visible by unit as unseen
-                const srcVisible = map.getVisibleTilesCoords(unit);
-                for (const coords of srcVisible) {
-                    map.setTileVisibility(civID, coords, false);
-                }
                 unit.movement -= dst.getMovementCost(unit);
                 map.moveUnitTo(unit, dstCoords);
-                // mark tiles now visible by unit as seen
-                const newVisible = map.getVisibleTilesCoords(unit);
-                for (const coords of newVisible) {
-                    map.setTileVisibility(civID, coords, true);
-                }
                 src = dst;
                 finalCoords = dstCoords;
             }

--- a/dist/server/methods.js
+++ b/dist/server/methods.js
@@ -299,24 +299,29 @@ const methods = {
             const map = world.map;
             const src = map.getTile(srcCoords);
             const unit = src.unit;
-            if (unit) {
-                const target = map.getTile(targetCoords);
-                if (!unit || unit.civID !== civID) {
-                    game.sendUpdates();
-                    return;
+            const target = map.getTile(targetCoords);
+            if (!unit || unit.civID !== civID) {
+                game.sendUpdates();
+                return;
+            }
+            if (target.unit && map.canUnitAttack(unit, target.unit) && unit.movement > 0) {
+                if (unit.promotionClass === unit_1.PromotionClass.RANGED) {
+                    world.rangedCombat(unit, target.unit);
+                    unit.movement = 0;
                 }
-                if (target.unit && map.canUnitAttack(unit, target.unit) && unit.movement > 0) {
-                    if (unit.promotionClass === unit_1.PromotionClass.RANGED) {
-                        world.rangedCombat(unit, target.unit);
-                        unit.movement = 0;
-                    }
-                    else {
-                        world.meleeCombat(unit, target.unit);
-                        unit.movement = 0;
-                    }
+                else {
+                    world.meleeCombat(unit, target.unit);
+                    unit.movement = 0;
                 }
             }
             game.sendUpdates();
+            // In case we later support units being moved as a result of them attacking,
+            // we want to send a unit position update here. It also simplifies frontend logic.
+            game.sendToCiv(civID, {
+                update: [
+                    ['unitPositionUpdate', [srcCoords, unit.coords]],
+                ],
+            });
         }
     },
     moveUnit: (ws, srcCoords, path, attack) => {

--- a/dist/server/methods.js
+++ b/dist/server/methods.js
@@ -50,7 +50,7 @@ exports.games = {
 (() => __awaiter(void 0, void 0, void 0, function* () {
     exports.games[1] = yield game_1.Game.load('singleplayer test');
     // games[2] = await Game.load('no units test')
-    // games[2] = await Game.load('multiplayer test')
+    exports.games[2] = yield game_1.Game.load('multiplayer test');
 }))();
 const createGame = (username, playerCount, mapOptions, options) => {
     var _a;

--- a/dist/server/methods.js
+++ b/dist/server/methods.js
@@ -398,7 +398,7 @@ const methods = {
         if (game) {
             const map = game.world.map;
             const tile = map.getTile(coords);
-            if (((_a = tile.owner) === null || _a === void 0 ? void 0 : _a.civID) === civID && tile.unit) {
+            if (((_a = tile.owner) === null || _a === void 0 ? void 0 : _a.civID) === civID && tile.unit && map.canBuildOn(tile)) {
                 game.sendToCiv(civID, {
                     update: [
                         ['improvementCatalog', [coords, tile.getImprovementCatalog()]],

--- a/dist/server/utils/index.js
+++ b/dist/server/utils/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getAdjacentCoords = exports.mod = void 0;
+exports.arrayIncludesCoords = exports.getAdjacentCoords = exports.mod = void 0;
 const mod = (a, b) => {
     if (a >= 0) {
         return a % b;
@@ -31,4 +31,12 @@ const getAdjacentCoords = ({ x, y }) => {
     return coordArray;
 };
 exports.getAdjacentCoords = getAdjacentCoords;
+const arrayIncludesCoords = (array, { x, y }) => {
+    for (const coords of array) {
+        if (coords.x === x && coords.y === y)
+            return true;
+    }
+    return false;
+};
+exports.arrayIncludesCoords = arrayIncludesCoords;
 //# sourceMappingURL=index.js.map

--- a/dist/server/utils/index.js
+++ b/dist/server/utils/index.js
@@ -32,14 +32,23 @@ const getAdjacentCoords = ({ x, y }) => {
 };
 exports.getAdjacentCoords = getAdjacentCoords;
 const getCoordInDirection = ({ x, y }, direction) => {
-    const coordsDial = [
-        { x: x, y: y + 1 },
-        { x: x + 1, y: y + 1 },
-        { x: x + 1, y: y },
-        { x: x, y: y - 1 },
-        { x: x - 1, y: y },
-        { x: x - 1, y: y + 1 },
-    ];
+    const coordsDial = (0, exports.mod)(x, 2) === 1 ?
+        [
+            { x: x, y: y + 1 },
+            { x: x + 1, y: y + 1 },
+            { x: x + 1, y: y },
+            { x: x, y: y - 1 },
+            { x: x - 1, y: y },
+            { x: x - 1, y: y + 1 },
+        ] :
+        [
+            { x: x, y: y + 1 },
+            { x: x + 1, y: y },
+            { x: x + 1, y: y - 1 },
+            { x: x, y: y - 1 },
+            { x: x - 1, y: y - 1 },
+            { x: x - 1, y: y },
+        ];
     return coordsDial[(0, exports.mod)(direction, 6)];
 };
 exports.getCoordInDirection = getCoordInDirection;

--- a/dist/server/utils/index.js
+++ b/dist/server/utils/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.arrayIncludesCoords = exports.getAdjacentCoords = exports.mod = void 0;
+exports.arrayIncludesCoords = exports.getCoordInDirection = exports.getAdjacentCoords = exports.mod = void 0;
 const mod = (a, b) => {
     if (a >= 0) {
         return a % b;
@@ -31,6 +31,18 @@ const getAdjacentCoords = ({ x, y }) => {
     return coordArray;
 };
 exports.getAdjacentCoords = getAdjacentCoords;
+const getCoordInDirection = ({ x, y }, direction) => {
+    const coordsDial = [
+        { x: x, y: y + 1 },
+        { x: x + 1, y: y + 1 },
+        { x: x + 1, y: y },
+        { x: x, y: y - 1 },
+        { x: x - 1, y: y },
+        { x: x - 1, y: y + 1 },
+    ];
+    return coordsDial[(0, exports.mod)(direction, 6)];
+};
+exports.getCoordInDirection = getCoordInDirection;
 const arrayIncludesCoords = (array, { x, y }) => {
     for (const coords of array) {
         if (coords.x === x && coords.y === y)

--- a/src/client/camera.ts
+++ b/src/client/camera.ts
@@ -341,10 +341,10 @@ class Camera {
                   world.attack(this.selectedUnitPos, {x, y}, selectedUnit as RangedUnit);
                 } else if (world.posIndex({x, y}) in this.highlightedTiles) {
                   world.moveUnit(this.selectedUnitPos, {x, y}, this.highlightedTiles, !!tile.unit);
+                } else {
+                  this.deselectUnit(world);
                 }
               }
-
-              this.deselectUnit(world);
             }
 
             ctx.drawImage(

--- a/src/client/camera.ts
+++ b/src/client/camera.ts
@@ -336,7 +336,12 @@ class Camera {
               console.log(x, y);
 
               if (this.selectedUnitPos && world.posIndex({x, y}) in this.highlightedTiles) {
-                world.moveUnit(this.selectedUnitPos, {x, y}, this.highlightedTiles, !!tile.unit);
+                const selectedUnit = world.getTile(this.selectedUnitPos).unit;
+                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED) {
+                  world.attack(this.selectedUnitPos, {x, y}, this.highlightedTiles, selectedUnit as RangedUnit);
+                } else {
+                  world.moveUnit(this.selectedUnitPos, {x, y}, this.highlightedTiles, !!tile.unit);
+                }
               }
 
               this.deselectUnit(world);

--- a/src/client/camera.ts
+++ b/src/client/camera.ts
@@ -335,11 +335,11 @@ class Camera {
 
               console.log(x, y);
 
-              if (this.selectedUnitPos && world.posIndex({x, y}) in this.highlightedTiles) {
+              if (this.selectedUnitPos) {
                 const selectedUnit = world.getTile(this.selectedUnitPos).unit;
                 if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED) {
-                  world.attack(this.selectedUnitPos, {x, y}, this.highlightedTiles, selectedUnit as RangedUnit);
-                } else {
+                  world.attack(this.selectedUnitPos, {x, y}, selectedUnit as RangedUnit);
+                } else if (world.posIndex({x, y}) in this.highlightedTiles) {
                   world.moveUnit(this.selectedUnitPos, {x, y}, this.highlightedTiles, !!tile.unit);
                 }
               }

--- a/src/client/camera.ts
+++ b/src/client/camera.ts
@@ -337,7 +337,7 @@ class Camera {
 
               if (this.selectedUnitPos) {
                 const selectedUnit = world.getTile(this.selectedUnitPos).unit;
-                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED) {
+                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && tile.unit.civID !== world.player.civID) {
                   world.attack(this.selectedUnitPos, {x, y}, selectedUnit as RangedUnit);
                 } else if (world.posIndex({x, y}) in this.highlightedTiles) {
                   world.moveUnit(this.selectedUnitPos, {x, y}, this.highlightedTiles, !!tile.unit);

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -24,6 +24,9 @@ const unitActionsTable: { [unit: string]: string[] } = {
   'settler': ['settleCity'],
   'scout': [],
   'builder': ['build'],
+  'warrior': [],
+  'slinger': [],
+  'archer': [],
 };
 
 const unitActionsFnTable: { [action: string]: (pos: Coords, ...args: any) => [string, unknown[]] } = {

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -232,7 +232,8 @@ class World {
     return farmableTiles[tile.type];
   }
 
-  areSameCoords(pos1: Coords, pos2: Coords): boolean {
+  areSameCoords(pos1: Coords | null, pos2: Coords | null): boolean {
+    if (pos1 === null || pos2 === null) return false;
     return pos1.x === pos2.x && pos1.y === pos2.y;
   }
 
@@ -529,7 +530,7 @@ class World {
         if (unit && unit.movement === 0) {
           this.unusedUnits.splice(this.unusedUnits.indexOf(index), 1);
         }
-        if (camera.selectedUnitPos?.x === startPos.x && camera.selectedUnitPos?.y === startPos.y) {
+        if (this.areSameCoords(camera.selectedUnitPos, startPos)) {
           camera.deselectUnit(this);
           if (unit.movement > 0) {
             camera.selectUnit(this, endPos, unit);

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -232,6 +232,10 @@ class World {
     return farmableTiles[tile.type];
   }
 
+  areSameCoords(pos1: Coords, pos2: Coords): boolean {
+    return pos1.x === pos2.x && pos1.y === pos2.y;
+  }
+
   // mode: 0 = land unit, 1 = sea unit; -1 = air unit
   getTilesInRange(srcPos: Coords, range: number, mode = 0): { [key: string]: Coords } {
     // BFS to find all tiles within `range` steps

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -525,6 +525,12 @@ class World {
         if (unit && unit.movement === 0) {
           this.unusedUnits.splice(this.unusedUnits.indexOf(index), 1);
         }
+        if (camera.selectedUnitPos?.x === startPos.x && camera.selectedUnitPos?.y === startPos.y) {
+          camera.deselectUnit(this);
+          if (unit.movement > 0) {
+            camera.selectUnit(this, endPos, unit);
+          }
+        }
       }
     };
 

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -503,7 +503,7 @@ class World {
     this.on.update.tileUpdate = (pos: Coords, tile: Tile): void => {
       this.tiles[this.posIndex(pos)] = tile;
       if (this.selectedPos && pos.x === this.selectedPos.x && pos.y === this.selectedPos.y) {
-        if (tile.improvement) {
+        if (tile.improvement && !tile.improvement.isNatural) {
           ui.hideSidebarMenu();
           ui.showSidebarMenu(this, pos, tile);
           this.fetchImprovementCatalogs(tile.improvement, pos);

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -43,6 +43,7 @@ interface Improvement {
   storage: ResourceStorage;
   errand?: Errand;
   metadata?: any;
+  isNatural: boolean;
 }
 
 enum ErrandType {
@@ -605,7 +606,7 @@ class World {
     this.on.event.selectTile = (coords: Coords, tile: Tile): void => {
       this.selectedPos = coords;
       ui.showTileInfoMenu(this, coords, tile);
-      if (tile.improvement) {
+      if (tile.improvement && !tile.improvement.isNatural) {
         this.fetchImprovementCatalogs(tile.improvement, coords);
         ui.showSidebarMenu(this, coords, tile);
       } else {

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -268,10 +268,9 @@ class World {
     return path;
   }
 
-  attack(srcPos: Coords, dstPos: Coords, pathMap: { [key: string]: Coords }, attacker: RangedUnit) {
-    const path = this.findPath(srcPos, dstPos, pathMap);
-    // TODO - this is NOT robust!
-    if (path.length <= attacker.attackRange) {
+  attack(srcPos: Coords, dstPos: Coords, attacker: RangedUnit) {
+    const reachableTiles = this.getTilesInRange(srcPos, attacker.attackRange)
+    if (Object.keys(reachableTiles).includes(this.posIndex(dstPos).toString())) {
       this.sendActions([
         ['attack', [ srcPos, dstPos ]]
       ]);

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -270,6 +270,7 @@ class World {
 
   attack(srcPos: Coords, dstPos: Coords, pathMap: { [key: string]: Coords }, attacker: RangedUnit) {
     const path = this.findPath(srcPos, dstPos, pathMap);
+    // TODO - this is NOT robust!
     if (path.length <= attacker.attackRange) {
       this.sendActions([
         ['attack', [ srcPos, dstPos ]]

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -23,6 +23,18 @@ interface Unit {
   hp: number;
   movement: number;
   civID: number;
+  promotionClass: PromotionClass;
+}
+
+interface RangedUnit extends Unit {
+  attackRange: number;
+}
+
+enum PromotionClass {
+  CIVILLIAN,
+  MELEE,
+  RANGED,
+  RECON,
 }
 
 interface Improvement {
@@ -244,8 +256,7 @@ class World {
     return paths;
   }
 
-  moveUnit(srcPos: Coords, dstPos: Coords, pathMap: { [key: string]: Coords }, attack: boolean): void {
-    console.log(srcPos, dstPos, pathMap);
+  findPath(srcPos: Coords, dstPos: Coords, pathMap: { [key: string]: Coords }): Coords[] {
     let curPos: Coords = dstPos;
     const path: Coords[] = [];
     while (this.posIndex(srcPos) !== this.posIndex(curPos)) {
@@ -254,6 +265,21 @@ class World {
       curPos = pathMap[this.posIndex(curPos)];
     }
     path.reverse();
+    return path;
+  }
+
+  attack(srcPos: Coords, dstPos: Coords, pathMap: { [key: string]: Coords }, attacker: RangedUnit) {
+    const path = this.findPath(srcPos, dstPos, pathMap);
+    if (path.length <= attacker.attackRange) {
+      this.sendActions([
+        ['attack', [ srcPos, dstPos ]]
+      ]);
+    }
+  }
+
+  moveUnit(srcPos: Coords, dstPos: Coords, pathMap: { [key: string]: Coords }, attack: boolean): void {
+    console.log(srcPos, dstPos, pathMap);
+    const path = this.findPath(srcPos, dstPos, pathMap);
     this.sendActions([
       ['moveUnit', [ srcPos, path, attack ]]
     ]);

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -106,6 +106,16 @@ type Coords = {
 
 type MovementCost = [number, number];
 
+const canTrainUnits: { [improvement: string]: boolean } = {
+  'settlement': true,
+  'encampment': true,
+};
+
+const canResearch: { [improvement: string]: boolean } = {
+  'settlement': true,
+  'campus': true,
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class World {
   tiles: Tile[];
@@ -314,11 +324,10 @@ class World {
   }
 
   fetchImprovementCatalogs(improvement: Improvement, coords: Coords): void {
-    if (improvement.type === 'encampment') {
-      // change this check later, to be more general
+    if (canTrainUnits[improvement.type]) {
       this.sendActions([[ 'getUnitCatalog', [coords] ]])
-    } else if (improvement.type === 'campus') {
-      // change this check later, to be more general
+    }
+    if (canResearch[improvement.type]) {
       this.sendActions([[ 'getKnowledgeCatalog', [coords] ]])
     }
   }

--- a/src/server/game/map/generator/index.ts
+++ b/src/server/game/map/generator/index.ts
@@ -43,6 +43,7 @@ export class PerlinWorldGenerator {
   private simplex: SimplexNoise;
   private width: number;
   private height: number;
+  private seaLevel: number;
   private biomes: { [key: string]: Biome }
 
   constructor(seed: number, { width, height }: MapOptions) {
@@ -52,18 +53,20 @@ export class PerlinWorldGenerator {
     this.height = height;
 
     // Elevation Constants - Make these configurable later
-    const SEA_LEVEL = 45;
+    const OCEAN_LEVEL = 45;
     const COAST_LEVEL = 55;
     const PLAINS_LEVEL = 60;
     const HILLS_LEVEL = 80;
     const HIGHLANDS_LEVEL = 90;
     const MOUNTAIN_LEVEL = 98;
 
+    this.seaLevel = COAST_LEVEL;
+
     // Define Biomes
     this.biomes = {
       'plains': new Biome(this.random,
         OCEAN, [
-          [SEA_LEVEL, SHALLOW_OCEAN],
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
           [COAST_LEVEL, GRASS_LOWLANDS],
           [PLAINS_LEVEL, GRASS_PLAINS],
           [HILLS_LEVEL, new TilePool([[GRASS_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
@@ -73,7 +76,7 @@ export class PerlinWorldGenerator {
       ),
       'temperate_forest': new Biome(this.random,
         OCEAN, [
-          [SEA_LEVEL, SHALLOW_OCEAN],
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
           [COAST_LEVEL, TEMPERATE_FOREST_LOWLANDS],
           [PLAINS_LEVEL, TEMPERATE_FOREST_PLAINS],
           [HILLS_LEVEL, new TilePool([[TEMPERATE_FOREST_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
@@ -83,8 +86,8 @@ export class PerlinWorldGenerator {
       ),
       'tundra': new Biome(this.random,
         OCEAN, [
-          [SEA_LEVEL, SHALLOW_OCEAN],
-          [SEA_LEVEL + 5, FROZEN_RIVER],
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
+          [OCEAN_LEVEL + 5, FROZEN_RIVER],
           [COAST_LEVEL, SNOW_PLAINS],
           [HILLS_LEVEL, SNOW_HILLS],
           [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
@@ -93,7 +96,7 @@ export class PerlinWorldGenerator {
       ),
       'arctic': new Biome(this.random,
         FROZEN_OCEAN, [
-          [SEA_LEVEL, SHALLOW_FROZEN_OCEAN],
+          [OCEAN_LEVEL, SHALLOW_FROZEN_OCEAN],
           [COAST_LEVEL, SNOW_PLAINS],
           [HILLS_LEVEL, SNOW_HILLS],
           [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
@@ -102,7 +105,7 @@ export class PerlinWorldGenerator {
       ),
       'desert': new Biome(this.random,
         OCEAN, [
-          [SEA_LEVEL, SHALLOW_OCEAN],
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
           [COAST_LEVEL, DESERT_PLAINS],
           [HILLS_LEVEL, DESERT_HILLS],
           [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
@@ -111,7 +114,7 @@ export class PerlinWorldGenerator {
       ),
       'mild_desert': new Biome(this.random,
         OCEAN, [
-          [SEA_LEVEL, SHALLOW_OCEAN],
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
           [COAST_LEVEL, new TilePool([[DESERT_PLAINS, 3], [GRASS_LOWLANDS, 1]])], // TODO - replace grass lowlands with desert lowlands
           [PLAINS_LEVEL, DESERT_PLAINS],
           [HILLS_LEVEL, DESERT_HILLS],
@@ -222,7 +225,7 @@ export class PerlinWorldGenerator {
     let i = 0;
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
-        const tile = new Tile(tileTypeMap[i].type, heightMap[i], new Yield(tileTypeMap[i].yieldParams));
+        const tile = new Tile(tileTypeMap[i].type, Math.max(heightMap[i], this.seaLevel), new Yield(tileTypeMap[i].yieldParams));
 
         const vegetation = tileTypeMap[i].getVegetation(this.random);
         if (vegetation) tile.improvement = new Improvement(vegetation, tile.baseYield);

--- a/src/server/game/map/index.ts
+++ b/src/server/game/map/index.ts
@@ -166,12 +166,12 @@ export class Map {
     return [paths, dst];
   }
 
-  getVisibleTilesCoords(unit: Unit, visionRange = 2): Coords[] {
-    return [unit.coords, ...this.getNeighborsCoords(unit.coords, visionRange)];
+  getVisibleTilesCoords(unit: Unit, range?: number): Coords[] {
+    return [unit.coords, ...this.getNeighborsCoords(unit.coords, range ?? unit.visionRange)];
   }
 
   canUnitSee(unit: Unit, targetCoords: Coords, isAttack = false): boolean {
-    const visibleTiles = this.getVisibleTilesCoords(unit, isAttack ? (unit.attackRange ?? 1) : 2);
+    const visibleTiles = this.getVisibleTilesCoords(unit, isAttack ? (unit.attackRange ?? 1) : unit.visionRange);
     return arrayIncludesCoords(visibleTiles, targetCoords);
   }
 

--- a/src/server/game/map/index.ts
+++ b/src/server/game/map/index.ts
@@ -245,14 +245,15 @@ export class Map {
     return coordsArray;
   }
 
-  canUnitSee(unit: Unit, targetCoords: Coords, isAttack = false): boolean {
+  canUnitSee(unit: Unit, targetCoords: Coords, options?: { isAttack?: boolean }): boolean {
+    const isAttack = options?.isAttack ?? false;
     const visibleTiles = this.getVisibleTilesCoords(unit, isAttack ? (unit.attackRange ?? 1) : unit.visionRange);
     return arrayIncludesCoords(visibleTiles, targetCoords);
   }
 
   canUnitAttack(unit: Unit, target: Unit): boolean {
     if (unit.promotionClass === PromotionClass.RANGED) {
-      return this.canUnitSee(unit, target.coords, true);
+      return this.canUnitSee(unit, target.coords, { isAttack: true });
     } else {
       return unit.isAdjacentTo(target.coords);
     }

--- a/src/server/game/map/index.ts
+++ b/src/server/game/map/index.ts
@@ -1,9 +1,9 @@
 import { Coords, World } from '../world';
-import { MovementClass, Unit } from './tile/unit';
+import { MovementClass, PromotionClass, Unit } from './tile/unit';
 import { City } from './tile/city';
 import { Tile, TileData } from './tile';
 import { Improvement, Worksite } from './tile/improvement';
-import { getAdjacentCoords, mod, Event } from '../../utils';
+import { getAdjacentCoords, mod, Event, arrayIncludesCoords } from '../../utils';
 import { Route, Trader, TraderData } from './trade';
 import { Yield, YieldParams } from './tile/yield';
 import { ErrandType } from './tile/errand';
@@ -166,8 +166,21 @@ export class Map {
     return [paths, dst];
   }
 
-  getVisibleTilesCoords(unit: Unit): Coords[] {
-    return [unit.coords, ...this.getNeighborsCoords(unit.coords, 2)];
+  getVisibleTilesCoords(unit: Unit, visionRange = 2): Coords[] {
+    return [unit.coords, ...this.getNeighborsCoords(unit.coords, visionRange)];
+  }
+
+  canUnitSee(unit: Unit, targetCoords: Coords, isAttack = false): boolean {
+    const visibleTiles = this.getVisibleTilesCoords(unit, isAttack ? (unit.attackRange ?? 1) : 2);
+    return arrayIncludesCoords(visibleTiles, targetCoords);
+  }
+
+  canUnitAttack(unit: Unit, target: Unit): boolean {
+    if (unit.promotionClass === PromotionClass.RANGED) {
+      return this.canUnitSee(unit, target.coords, true);
+    } else {
+      return unit.isAdjacentTo(target.coords);
+    }
   }
 
   setTileOwner(coords: Coords, owner: City, overwrite: boolean): void {

--- a/src/server/game/map/index.ts
+++ b/src/server/game/map/index.ts
@@ -243,7 +243,6 @@ export class Map {
       );
     }
     return coordsArray;
-    // return [unit.coords, ...this.getNeighborsCoords(unit.coords, range ?? unit.visionRange)];
   }
 
   canUnitSee(unit: Unit, targetCoords: Coords, isAttack = false): boolean {

--- a/src/server/game/map/tile/improvement.ts
+++ b/src/server/game/map/tile/improvement.ts
@@ -10,6 +10,7 @@ export type ImprovementData = {
   storage: YieldParams;
   errand?: ErrandData;
   metadata?: any;
+  isNatural: boolean;
 };
 
 export class Improvement {
@@ -103,6 +104,7 @@ export class Improvement {
       pillaged: this.pillaged,
       storage: this.storage,
       errand: this.errand?.getData(),
+      isNatural: this.isNatural,
     };
   }
 

--- a/src/server/game/map/tile/improvement.ts
+++ b/src/server/game/map/tile/improvement.ts
@@ -39,6 +39,10 @@ export class Improvement {
     'forest': true,
   };
 
+  static improvementHeightTable: { [improvement: string]: number } = {
+    'forest': 5,
+  }
+
   static trainableUnitClassTable: { [improvement: string]: PromotionClass[] } = {
     'settlement': [PromotionClass.CIVILLIAN],
     'encampment': [PromotionClass.MELEE, PromotionClass.RANGED, PromotionClass.RECON],

--- a/src/server/game/map/tile/improvement.ts
+++ b/src/server/game/map/tile/improvement.ts
@@ -1,5 +1,5 @@
 import { Trader } from '../trade';
-import { ErrandAction, ErrandData, WorkErrand } from './errand';
+import { ErrandAction, ErrandData, ErrandType, WorkErrand } from './errand';
 import { Knowledge, KnowledgeBranch } from './knowledge';
 import { PromotionClass } from './unit';
 import { ResourceStore, Yield, YieldParams } from './yield';
@@ -12,6 +12,11 @@ export type ImprovementData = {
   metadata?: any;
   isNatural: boolean;
 };
+
+export interface ImprovementConstructionCost {
+  type: string;
+  cost: Yield;
+}
 
 export class Improvement {
   static yieldTable: { [improvement: string]: Yield } = {
@@ -53,6 +58,12 @@ export class Improvement {
   protected traders: Trader[];
   protected suppliers: Trader[];
   protected storage: ResourceStore;
+
+  static makeCatalog(types: string[]): ImprovementConstructionCost[] {
+    return types.map(type => (
+      { type, cost: WorkErrand.errandCostTable[ErrandType.CONSTRUCTION][type] }
+    ));
+  }
   
   constructor(type?: string, baseYield?: Yield, metadata?: any) {
     if (!(type && baseYield)) return;

--- a/src/server/game/map/tile/index.ts
+++ b/src/server/game/map/tile/index.ts
@@ -218,11 +218,11 @@ export class Tile {
    * @returns whether farms can be build on this tile
    */
   isFarmable(): boolean {
-    const farmableTiles = {
-      grass_lowlands: true,
-      plains: true,
+    const farmableTileTypes = {
+      'grass_lowlands': true,
+      'plains': true,
     };
-    return farmableTiles[this.type];
+    return this.type in farmableTileTypes;
   }
 
   /**
@@ -230,7 +230,7 @@ export class Tile {
    * @returns list of improvements the builder on this tile knows how to build
    */
    getBuildableImprovements(): string[] {
-    if (!(this.unit)) return [];
+    if (!this.unit) return [];
     return Knowledge.getBuildableImprovements(this.getKnowledges(true))
       .filter((improvementType) => {
         if (improvementType === 'farm' && !this.isFarmable()) return false;

--- a/src/server/game/map/tile/index.ts
+++ b/src/server/game/map/tile/index.ts
@@ -1,5 +1,5 @@
 import { Unit, UnitData, UnitTypeCost } from './unit';
-import { Improvement, ImprovementData } from './improvement';
+import { Improvement, ImprovementConstructionCost, ImprovementData } from './improvement';
 import { City, CityData } from './city';
 import { Yield, YieldParams } from './yield';
 import { Knowledge } from './knowledge';
@@ -205,6 +205,15 @@ export class Tile {
 
   /**
    * 
+   * @returns list of improvements the builder on this tile knows how to build
+   */
+   getBuildableImprovements(): string[] {
+    if (!(this.unit)) return [];
+    return Knowledge.getBuildableImprovements(this.getKnowledges(true));
+  }
+
+  /**
+   * 
    * @returns list of units classes this improvement knows how to train
    */
    getTrainableUnitTypes(): string[] {
@@ -212,6 +221,17 @@ export class Tile {
     const trainableUnitClasses = this.improvement.getTrainableUnitClasses().reduce((obj, name) => ({ ...obj, [name]: true }), {});
     return Knowledge.getTrainableUnits(this.getKnowledges(true))
       .filter(unitType => trainableUnitClasses[Unit.promotionClassTable[unitType]]);
+  }
+
+  /**
+   * 
+   * @returns type and cost of improvements the builder on this tile knows how to build, or null if it cannot build improvements
+   */
+   getImprovementCatalog(): ImprovementConstructionCost[] | null {
+    const buildableImprovements = this.getBuildableImprovements();
+    const catalog = Improvement.makeCatalog(buildableImprovements);
+    if (catalog.length === 0) return null;
+    return catalog;
   }
 
   /**

--- a/src/server/game/map/tile/index.ts
+++ b/src/server/game/map/tile/index.ts
@@ -125,6 +125,14 @@ export class Tile {
     return mode > -1 ? this.movementCost[mode] || Infinity : 1;
   }
 
+  getTotalElevation(): number {
+    if (this.improvement) {
+      return this.elevation + Improvement.improvementHeightTable[this.improvement.type] ?? 0;
+    } else {
+      return this.elevation;
+    }
+  }
+
   setUnit(unit?: Unit): void {
     this.unit = unit;
   }

--- a/src/server/game/map/tile/index.ts
+++ b/src/server/game/map/tile/index.ts
@@ -205,11 +205,27 @@ export class Tile {
 
   /**
    * 
+   * @returns whether farms can be build on this tile
+   */
+  isFarmable(): boolean {
+    const farmableTiles = {
+      grass_lowlands: true,
+      plains: true,
+    };
+    return farmableTiles[this.type];
+  }
+
+  /**
+   * 
    * @returns list of improvements the builder on this tile knows how to build
    */
    getBuildableImprovements(): string[] {
     if (!(this.unit)) return [];
-    return Knowledge.getBuildableImprovements(this.getKnowledges(true));
+    return Knowledge.getBuildableImprovements(this.getKnowledges(true))
+      .filter((improvementType) => {
+        if (improvementType === 'farm' && !this.isFarmable()) return false;
+        return true;
+      });
   }
 
   /**

--- a/src/server/game/map/tile/index.ts
+++ b/src/server/game/map/tile/index.ts
@@ -125,12 +125,14 @@ export class Tile {
     return mode > -1 ? this.movementCost[mode] || Infinity : 1;
   }
 
+  /**
+   * 
+   * @returns the total elevation of this tile plus the height of any improvemnts on it, rounded to the nearest unit.
+   */
   getTotalElevation(): number {
-    if (this.improvement) {
-      return this.elevation + Improvement.improvementHeightTable[this.improvement.type] ?? 0;
-    } else {
-      return this.elevation;
-    }
+    return Math.round(
+      this.elevation + (this.improvement ? Improvement.improvementHeightTable[this.improvement.type] ?? 0 : 0)
+    );
   }
 
   setUnit(unit?: Unit): void {

--- a/src/server/game/map/tile/knowledge.ts
+++ b/src/server/game/map/tile/knowledge.ts
@@ -22,6 +22,8 @@ export class Knowledge {
   improvements: string[];
 
   public static knowledgeTree: { [name: string]: Knowledge } = {
+    'start': new Knowledge('start', KnowledgeBranch.DEVELOPMENT, new Yield({ science: 0 }), [], {units: ['settler', 'builder']}),
+    'food_0': new Knowledge('food_0', KnowledgeBranch.DEVELOPMENT, new Yield({ science: 10 }), [], {improvements: ['farm']}),
     'military_0': new Knowledge('military_0', KnowledgeBranch.OFFENSE, new Yield({ science: 10 }), [], {units: ['warrior', 'slinger']}),
     'recon_0': new Knowledge('recon_0', KnowledgeBranch.OFFENSE, new Yield({ science: 10 }), [], {units: ['scout']}),
     'ranged_1': new Knowledge('ranged_1', KnowledgeBranch.OFFENSE, new Yield({ science: 10 }), ['military_0'], {units: ['archer']}),

--- a/src/server/game/map/tile/unit.ts
+++ b/src/server/game/map/tile/unit.ts
@@ -75,6 +75,11 @@ export class Unit {
     'slinger': 2,
     'archer': 3,
   }
+
+  static visionRangeTable: { [unitType: string]: number } = {
+    default: 2,
+    'scout': 3,
+  }
   
   static costTable: { [unitType: string]: Yield } = {
     'settler': new Yield({production: 10}),
@@ -92,6 +97,7 @@ export class Unit {
   movementClass: MovementClass;
   combatStats: [number, number, number];
   attackRange?: number;
+  visionRange: number;
   civID: number;
   coords: Coords;
   alive: boolean;
@@ -112,6 +118,7 @@ export class Unit {
     if (this.promotionClass === PromotionClass.RANGED) {
       this.attackRange = Unit.attackRangeTable[type];
     }
+    this.visionRange = Unit.visionRangeTable[type] ?? Unit.visionRangeTable.default;
     this.civID = civID;
     this.coords = coords;
     this.alive = true;

--- a/src/server/game/map/tile/unit.ts
+++ b/src/server/game/map/tile/unit.ts
@@ -12,6 +12,8 @@ export interface UnitData {
   hp: number,
   movement: number,
   civID: number,
+  promotionClass: PromotionClass,
+  attackRange?: number,
 }
 
 export enum MovementClass {
@@ -68,6 +70,11 @@ export class Unit {
     'archer': [15, 5, 12],
     'spy': [5, 3, 20],
   }
+
+  static attackRangeTable: { [unitType: string]: number } = {
+    'slinger': 2,
+    'archer': 3,
+  }
   
   static costTable: { [unitType: string]: Yield } = {
     'settler': new Yield({production: 10}),
@@ -84,6 +91,7 @@ export class Unit {
   promotionClass: PromotionClass;
   movementClass: MovementClass;
   combatStats: [number, number, number];
+  attackRange?: number;
   civID: number;
   coords: Coords;
   alive: boolean;
@@ -101,6 +109,9 @@ export class Unit {
     this.promotionClass = Unit.promotionClassTable[type];
     this.movementClass = Unit.movementClassTable[type];
     this.combatStats = Unit.combatStatsTable[type];
+    if (this.promotionClass === PromotionClass.RANGED) {
+      this.attackRange = Unit.attackRangeTable[type];
+    }
     this.civID = civID;
     this.coords = coords;
     this.alive = true;
@@ -111,9 +122,6 @@ export class Unit {
       type: this.type,
       hp: this.hp,
       movement: this.movement,
-      promotionClass: this.promotionClass,
-      movementClass: this.movementClass,
-      combatStats: this.combatStats,
       civID: this.civID,
       coords: this.coords,
       alive: this.alive,
@@ -124,9 +132,12 @@ export class Unit {
     const unit = new Unit(data.type, data.civID, data.coords);
     unit.hp = data.hp;
     unit.movement = data.movement;
-    unit.promotionClass = data.promotionClass;
-    unit.movementClass = data.movementClass;
-    unit.combatStats = data.combatStats;
+    unit.promotionClass = Unit.promotionClassTable[unit.type];
+    unit.movementClass = Unit.movementClassTable[unit.type];
+    unit.combatStats = Unit.combatStatsTable[unit.type];
+    if (unit.promotionClass === PromotionClass.RANGED) {
+      unit.attackRange = Unit.attackRangeTable[unit.type];
+    }
     unit.alive = data.alive;
     return unit;
   }
@@ -137,6 +148,8 @@ export class Unit {
       hp: this.hp,
       movement: this.movement,
       civID: this.civID,
+      promotionClass: this.promotionClass,
+      attackRange: this.attackRange,
     };
   }
   

--- a/src/server/game/map/tile/unit.ts
+++ b/src/server/game/map/tile/unit.ts
@@ -81,7 +81,8 @@ export class Unit {
   type: string;
   hp: number; // this should never be allowed to be outside the range 0 - 100
   movement: number;
-  movementClass: number;
+  promotionClass: PromotionClass;
+  movementClass: MovementClass;
   combatStats: [number, number, number];
   civID: number;
   coords: Coords;
@@ -97,6 +98,7 @@ export class Unit {
     this.type = type;
     this.hp = 100;
     this.movement = 0;
+    this.promotionClass = Unit.promotionClassTable[type];
     this.movementClass = Unit.movementClassTable[type];
     this.combatStats = Unit.combatStatsTable[type];
     this.civID = civID;
@@ -109,6 +111,7 @@ export class Unit {
       type: this.type,
       hp: this.hp,
       movement: this.movement,
+      promotionClass: this.promotionClass,
       movementClass: this.movementClass,
       combatStats: this.combatStats,
       civID: this.civID,
@@ -121,6 +124,7 @@ export class Unit {
     const unit = new Unit(data.type, data.civID, data.coords);
     unit.hp = data.hp;
     unit.movement = data.movement;
+    unit.promotionClass = data.promotionClass;
     unit.movementClass = data.movementClass;
     unit.combatStats = data.combatStats;
     unit.alive = data.alive;

--- a/src/server/methods.ts
+++ b/src/server/methods.ts
@@ -52,7 +52,7 @@ export const games: { [gameID: number] : Game } = {
 (async () => {
   games[1] = await Game.load('singleplayer test')
   // games[2] = await Game.load('no units test')
-  // games[2] = await Game.load('multiplayer test')
+  games[2] = await Game.load('multiplayer test')
 })()
 
 const createGame = (username: string, playerCount: number, mapOptions: MapOptions, options: { seed?: number, gameName?: string }) => {

--- a/src/server/methods.ts
+++ b/src/server/methods.ts
@@ -344,26 +344,33 @@ const methods: {
 
       const src = map.getTile(srcCoords);
       const unit = src.unit;
-      if (unit) {
-        const target = map.getTile(targetCoords);
 
-        if ( !unit || unit.civID !== civID ) {
-          game.sendUpdates();
-          return;
-        }
+      const target = map.getTile(targetCoords);
 
-        if (target.unit && map.canUnitAttack(unit, target.unit) && unit.movement > 0) {
-          if (unit.promotionClass === PromotionClass.RANGED) {
-            world.rangedCombat(unit, target.unit);
-            unit.movement = 0;
-          } else {
-            world.meleeCombat(unit, target.unit);
-            unit.movement = 0;
-          }
+      if ( !unit || unit.civID !== civID ) {
+        game.sendUpdates();
+        return;
+      }
+
+      if (target.unit && map.canUnitAttack(unit, target.unit) && unit.movement > 0) {
+        if (unit.promotionClass === PromotionClass.RANGED) {
+          world.rangedCombat(unit, target.unit);
+          unit.movement = 0;
+        } else {
+          world.meleeCombat(unit, target.unit);
+          unit.movement = 0;
         }
       }
 
       game.sendUpdates();
+
+      // In case we later support units being moved as a result of them attacking,
+      // we want to send a unit position update here. It also simplifies frontend logic.
+      game.sendToCiv(civID, {
+        update: [
+          ['unitPositionUpdate', [srcCoords, unit.coords]],
+        ],
+      });
     }
   },
 

--- a/src/server/methods.ts
+++ b/src/server/methods.ts
@@ -465,7 +465,7 @@ const methods: {
     if (game) {
       const map = game.world.map;
       const tile = map.getTile(coords);
-      if (tile.owner?.civID === civID && tile.unit) {
+      if (tile.owner?.civID === civID && tile.unit && map.canBuildOn(tile)) {
         game.sendToCiv(civID, {
           update: [
             ['improvementCatalog', [coords, tile.getImprovementCatalog()]],

--- a/src/server/methods.ts
+++ b/src/server/methods.ts
@@ -451,6 +451,30 @@ const methods: {
     }
   },
 
+  /**
+   * The list of improvements the builder on the given coords is able to build
+   * @param coords 
+   */
+  getImprovementCatalog: (ws: WebSocket, coords: Coords) => {
+    const username = getUsername(ws);
+    const gameID = getGameID(ws);
+
+    const game = games[gameID];
+    const civID = game.players[username].civID;
+
+    if (game) {
+      const map = game.world.map;
+      const tile = map.getTile(coords);
+      if (tile.owner?.civID === civID && tile.unit) {
+        game.sendToCiv(civID, {
+          update: [
+            ['improvementCatalog', [coords, tile.getImprovementCatalog()]],
+          ],
+        });
+      }
+    }
+  },
+
   buildImprovement: (ws: WebSocket, coords: Coords, type: string) => {
     const username = getUsername(ws);
     const gameID = getGameID(ws);

--- a/src/server/methods.ts
+++ b/src/server/methods.ts
@@ -358,20 +358,8 @@ const methods: {
           break;
         }
 
-        // mark tiles currently visible by unit as unseen
-        const srcVisible = map.getVisibleTilesCoords(unit);
-        for (const coords of srcVisible) {
-          map.setTileVisibility(civID, coords, false);
-        }
-
         unit.movement -= dst.getMovementCost(unit);
         map.moveUnitTo(unit, dstCoords);
-
-        // mark tiles now visible by unit as seen
-        const newVisible = map.getVisibleTilesCoords(unit);
-        for (const coords of newVisible) {
-          map.setTileVisibility(civID, coords, true);
-        }
 
         src = dst;
         finalCoords = dstCoords;

--- a/src/server/methods.ts
+++ b/src/server/methods.ts
@@ -352,7 +352,7 @@ const methods: {
           return;
         }
 
-        if (target.unit && map.canUnitAttack(unit, target.unit)) {
+        if (target.unit && map.canUnitAttack(unit, target.unit) && unit.movement > 0) {
           if (unit.promotionClass === PromotionClass.RANGED) {
             world.rangedCombat(unit, target.unit);
             unit.movement = 0;

--- a/src/server/utils/index.ts
+++ b/src/server/utils/index.ts
@@ -41,6 +41,19 @@ export const getAdjacentCoords = ({x, y}: Coords): Coords[] => {
   return coordArray;
 };
 
+export const getCoordInDirection = ({x, y}: Coords, direction: number): Coords => {
+  const coordsDial = [
+    { x: x,   y: y+1 },
+    { x: x+1, y: y+1 },
+    { x: x+1, y: y   },
+    { x: x,   y: y-1 },
+    { x: x-1, y: y   },
+    { x: x-1, y: y+1 },
+  ];
+
+  return coordsDial[mod(direction, 6)];
+}
+
 export const arrayIncludesCoords = (array: Coords[], {x, y}: Coords): boolean => {
   for (const coords of array) {
     if (coords.x === x && coords.y === y) return true;

--- a/src/server/utils/index.ts
+++ b/src/server/utils/index.ts
@@ -42,14 +42,23 @@ export const getAdjacentCoords = ({x, y}: Coords): Coords[] => {
 };
 
 export const getCoordInDirection = ({x, y}: Coords, direction: number): Coords => {
-  const coordsDial = [
-    { x: x,   y: y+1 },
-    { x: x+1, y: y+1 },
-    { x: x+1, y: y   },
-    { x: x,   y: y-1 },
-    { x: x-1, y: y   },
-    { x: x-1, y: y+1 },
-  ];
+  const coordsDial = mod(x, 2) === 1 ? 
+    [
+      { x: x,   y: y+1 },
+      { x: x+1, y: y+1 },
+      { x: x+1, y: y   },
+      { x: x,   y: y-1 },
+      { x: x-1, y: y   },
+      { x: x-1, y: y+1 },
+    ] :
+    [
+      { x: x,   y: y+1 },
+      { x: x+1, y: y   },
+      { x: x+1, y: y-1 },
+      { x: x,   y: y-1 },
+      { x: x-1, y: y-1 },
+      { x: x-1, y: y   },
+    ];
 
   return coordsDial[mod(direction, 6)];
 }

--- a/src/server/utils/index.ts
+++ b/src/server/utils/index.ts
@@ -18,7 +18,7 @@ export const mod = (a: number, b: number): number => {
   } else {
     return ((a % b) + b) % b;
   }
-}
+};
 
 export const getAdjacentCoords = ({x, y}: Coords): Coords[] => {
   const coordArray: Coords[] = [];
@@ -39,4 +39,11 @@ export const getAdjacentCoords = ({x, y}: Coords): Coords[] => {
   }
 
   return coordArray;
-}
+};
+
+export const arrayIncludesCoords = (array: Coords[], {x, y}: Coords): boolean => {
+  for (const coords of array) {
+    if (coords.x === x && coords.y === y) return true;
+  }
+  return false;
+};


### PR DESCRIPTION
closes #82; closes #115; closes #128; closes #143; closes #144; closes #147; closes #149

- Add ranged combat
- Refactor unit vision code
- Quality of life changes for how you select units and tiles on the frontend
- Improvements builders can build is now dictated by the backend, not a table on the frontend