### PR TITLE
Leaders & Civs Rewrite

### DIFF
--- a/client/dist/camera.js
+++ b/client/dist/camera.js
@@ -1,3 +1,4 @@
+const DEFAULT_COLOR = '#333';
 const [TILE_WIDTH, TILE_HEIGHT] = [28, 26];
 const X_TILE_SPACING = TILE_WIDTH * 3 / 4;
 const Y_TILE_SPACING = TILE_HEIGHT / 2;
@@ -146,7 +147,7 @@ class Camera {
         if (unit.cloaked)
             ctx.globalAlpha = 0.5;
         // Unit Color Background
-        ctx.fillStyle = (_b = (_a = civs[unit.civID]) === null || _a === void 0 ? void 0 : _a.color) !== null && _b !== void 0 ? _b : (unit.isBarbarian ? '#F00' : '#333');
+        ctx.fillStyle = unit.domainID.type === DomainType.CIVILIZATION ? ((_b = (_a = civs[unit.domainID.subID]) === null || _a === void 0 ? void 0 : _a.color) !== null && _b !== void 0 ? _b : DEFAULT_COLOR) : DEFAULT_COLOR;
         ctx.beginPath();
         ctx.rect((-camX + ((x - (width / 2)) * X_TILE_SPACING) + 6.5) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING)) + 5) * zoom, UNIT_WIDTH * zoom, UNIT_RECT_HEIGHT * zoom);
         ctx.arc((-camX + ((x - (width / 2)) * X_TILE_SPACING) + 6.5 + (UNIT_WIDTH / 2)) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING)) + 5 + UNIT_RECT_HEIGHT) * zoom, (UNIT_WIDTH / 2) * zoom, 0, Math.PI);
@@ -268,7 +269,7 @@ class Camera {
                         ctx.beginPath();
                         ctx.lineWidth = margin * 2;
                         ctx.lineCap = 'square';
-                        ctx.strokeStyle = world.civs[tile.owner.civID].color;
+                        ctx.strokeStyle = tile.owner.civID ? world.civs[tile.owner.civID.subID].color : DEFAULT_COLOR;
                         ctx.moveTo(leftX + leftCapXOffset + margin, topY + margin);
                         for (let i = 0; i < neighbors.length; i++) {
                             const neighbor = world.getTile(neighbors[i]);
@@ -279,7 +280,7 @@ class Camera {
                             else
                                 ctx.lineTo(...positions[i]);
                         }
-                        if (tile.owner.civID === world.player.civID)
+                        if (world.controlsTile(tile))
                             ctx.setLineDash([5 * zoom, 5 * zoom]);
                         ctx.stroke();
                         ctx.setLineDash([]);
@@ -308,7 +309,7 @@ class Camera {
                             console.log(x, y);
                             if (this.selectedUnitPos) {
                                 const selectedUnit = world.getTile(this.selectedUnitPos).unit;
-                                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && tile.unit.civID !== world.player.civID) {
+                                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && !world.controlsUnit(tile.unit)) {
                                     world.attack(this.selectedUnitPos, { x, y }, selectedUnit);
                                 }
                                 else if (world.posIndex({ x, y }) in this.highlightedTiles) {
@@ -320,7 +321,7 @@ class Camera {
                             }
                         }
                         ctx.drawImage(textures['selector'], (-camX + ((x - (width / 2)) * X_TILE_SPACING)) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING))) * zoom, TILE_WIDTH * zoom, TILE_HEIGHT * zoom);
-                        if (tile.unit && this.mouseDownTime === 1 && tile.unit.civID === world.player.civID && ui.turnActive) {
+                        if (tile.unit && this.mouseDownTime === 1 && world.controlsUnit(tile.unit) && ui.turnActive) {
                             console.log(tile.unit);
                             this.selectUnit(world, { x, y }, tile.unit);
                         }

--- a/client/dist/camera.js
+++ b/client/dist/camera.js
@@ -175,7 +175,7 @@ class Camera {
         ctx.stroke();
     }
     render(world) {
-        var _a, _b, _c, _d, _e;
+        var _a, _b, _c, _d, _e, _f;
         const { zoom, x: camX, y: camY, textures, ctx } = this;
         const { width, height } = world;
         const [wmX, wmY] = [camX + (mouseX / zoom), camY + (mouseY / zoom)];
@@ -275,7 +275,7 @@ class Camera {
                             const neighbor = world.getTile(neighbors[i]);
                             if (!neighbor)
                                 ctx.moveTo(...positions[i]);
-                            else if (((_c = neighbor.owner) === null || _c === void 0 ? void 0 : _c.civID) === tile.owner.civID)
+                            else if (compareDomainIDs((_c = neighbor.owner) === null || _c === void 0 ? void 0 : _c.civID, tile.owner.civID) || ((_d = neighbor.owner) === null || _d === void 0 ? void 0 : _d.id) === tile.owner.id)
                                 ctx.moveTo(...positions[i]);
                             else
                                 ctx.lineTo(...positions[i]);
@@ -329,7 +329,7 @@ class Camera {
                     if (!tile.visible)
                         ctx.globalAlpha = 0.5;
                     if (tile.improvement) {
-                        const overlay = (_d = textures.improvements[tile.improvement.type]) !== null && _d !== void 0 ? _d : textures.missing_overlay;
+                        const overlay = (_e = textures.improvements[tile.improvement.type]) !== null && _e !== void 0 ? _e : textures.missing_overlay;
                         ctx.drawImage(overlay.texture, (-camX + ((x - (width / 2)) * X_TILE_SPACING)) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING)) - overlay.offset) * zoom, TILE_WIDTH * zoom, overlay.texture.height * zoom);
                     }
                     ctx.globalAlpha = 1;
@@ -349,7 +349,7 @@ class Camera {
                     if (hasWalls) {
                         for (const i of [2, 3, 4]) {
                             if (tile.walls[i] !== null) {
-                                const overlay = (_e = textures.improvements[`wall_${tile.walls[i].type}_${i}`]) !== null && _e !== void 0 ? _e : textures.missing_overlay;
+                                const overlay = (_f = textures.improvements[`wall_${tile.walls[i].type}_${i}`]) !== null && _f !== void 0 ? _f : textures.missing_overlay;
                                 ctx.drawImage(overlay.texture, (-camX + ((x - (width / 2)) * X_TILE_SPACING)) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING)) - overlay.offset) * zoom, TILE_WIDTH * zoom, overlay.texture.height * zoom);
                             }
                         }

--- a/client/dist/camera.js
+++ b/client/dist/camera.js
@@ -280,7 +280,7 @@ class Camera {
                             else
                                 ctx.lineTo(...positions[i]);
                         }
-                        if (world.controlsTile(tile))
+                        if (world.playerControlsTile(tile))
                             ctx.setLineDash([5 * zoom, 5 * zoom]);
                         ctx.stroke();
                         ctx.setLineDash([]);
@@ -309,7 +309,7 @@ class Camera {
                             console.log(x, y);
                             if (this.selectedUnitPos) {
                                 const selectedUnit = world.getTile(this.selectedUnitPos).unit;
-                                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && !world.controlsUnit(tile.unit)) {
+                                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && !world.playerControlsUnit(tile.unit)) {
                                     world.attack(this.selectedUnitPos, { x, y }, selectedUnit);
                                 }
                                 else if (world.posIndex({ x, y }) in this.highlightedTiles) {
@@ -321,7 +321,7 @@ class Camera {
                             }
                         }
                         ctx.drawImage(textures['selector'], (-camX + ((x - (width / 2)) * X_TILE_SPACING)) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING))) * zoom, TILE_WIDTH * zoom, TILE_HEIGHT * zoom);
-                        if (tile.unit && this.mouseDownTime === 1 && world.controlsUnit(tile.unit) && ui.turnActive) {
+                        if (tile.unit && this.mouseDownTime === 1 && world.playerControlsUnit(tile.unit) && ui.turnActive) {
                             console.log(tile.unit);
                             this.selectUnit(world, { x, y }, tile.unit);
                         }

--- a/client/dist/player.js
+++ b/client/dist/player.js
@@ -86,10 +86,10 @@ class UI {
             tileInfoMenu: this.createElement('div', { className: 'tileInfoMenu' }),
             sidebarMenu: this.createElement('div', { className: 'sidebarMenu' }),
         };
-        this.leaderPool = [];
-        this.takenLeaders = [];
+        this.civPool = {};
+        this.civTemplates = [];
         this.players = {};
-        this.civs = {};
+        this.leaders = {};
         this.turnActive = false;
         this.buttons = {
             mainBtn: new Button(this.createElement('button', { className: 'mainActionBtn' }), {
@@ -190,12 +190,12 @@ class UI {
         }
         return element;
     }
-    createCivItem(leader) {
+    createCivItem(civTemplate, selectedBy) {
         const civItem = this.createElement('li', { className: 'civItem' });
-        civItem.style.backgroundColor = leader.color;
-        civItem.style.color = leader.textColor;
+        civItem.style.backgroundColor = civTemplate.color;
+        civItem.style.color = civTemplate.textColor;
         const nameText = this.createElement('span');
-        nameText.innerHTML = `${leader.name}` + (leader.civID !== null ? ` - ${translate('menu.civ.selected_by')} ${this.civs[leader.civID].name}` : '');
+        nameText.innerHTML = `${civTemplate.name}` + (selectedBy !== null ? ` - ${translate('menu.civ.selected_by')} ${this.leaders[selectedBy.id].name}` : '');
         civItem.appendChild(nameText);
         return civItem;
     }
@@ -268,21 +268,22 @@ class UI {
         this.elements.civPicker.innerHTML = '';
         const selectedLeaderSlot = this.createElement('div', { className: 'selectedLeader' });
         this.elements.civPicker.appendChild(selectedLeaderSlot);
-        for (let i = 0; i < this.leaderPool.length; i++) {
-            const leader = this.leaderPool[i];
-            const civItem = this.createCivItem(leader);
-            civItem.onclick = () => {
-                callback(leader.id);
-            };
-            this.elements.civPicker.appendChild(civItem);
-        }
-        for (let i = 0; i < this.takenLeaders.length; i++) {
-            const leader = this.takenLeaders[i];
-            const civItem = this.createCivItem(leader);
-            civItem.onclick = () => {
-                alert(translate('error.civ_taken'));
-            };
-            if (leader.civID === self.civID) {
+        for (let civTemplateID = 0; civTemplateID < this.civTemplates.length; civTemplateID++) {
+            const civTemplate = this.civTemplates[civTemplateID];
+            const leaderID = this.civPool[civTemplateID];
+            const leader = leaderID !== null ? world.leaders[leaderID] : null;
+            const civItem = this.createCivItem(civTemplate, leader);
+            if (leader) {
+                civItem.onclick = () => {
+                    alert(translate('error.civ_taken'));
+                };
+            }
+            else {
+                civItem.onclick = () => {
+                    callback(civTemplateID);
+                };
+            }
+            if (leader && leader.id === self.leaderID) {
                 selectedLeaderSlot.appendChild(civItem);
             }
             else {
@@ -496,7 +497,8 @@ class UI {
         this.elements.tileInfoMenu.appendChild(tileKnowledge);
         if (tile.owner) {
             const tileOwner = this.createElement('span', { className: 'infoSpan' });
-            tileOwner.innerText = `${translate('tile.info.owner')}: ${world.civs[tile.owner.civID].leader.name}`;
+            // TODO
+            // tileOwner.innerText = `${translate('tile.info.owner')}: ${world.civs[tile.owner.civID].leader.name}`;
             this.elements.tileInfoMenu.appendChild(tileOwner);
         }
         this.root.appendChild(this.elements.tileInfoMenu);

--- a/client/dist/player.js
+++ b/client/dist/player.js
@@ -481,7 +481,7 @@ class UI {
         this.elements.unitInfoMenu.innerHTML = '';
     }
     showTileInfoMenu(world, pos, tile) {
-        var _a;
+        var _a, _b;
         this.elements.tileInfoMenu.innerHTML = '';
         const tileType = this.createElement('span', { className: 'infoSpan' });
         tileType.innerText = `${translate('tile.info.type')}: ${translate(`tile.${tile.type}`)}`;
@@ -497,8 +497,8 @@ class UI {
         this.elements.tileInfoMenu.appendChild(tileKnowledge);
         if (tile.owner) {
             const tileOwner = this.createElement('span', { className: 'infoSpan' });
-            // TODO
-            // tileOwner.innerText = `${translate('tile.info.owner')}: ${world.civs[tile.owner.civID].leader.name}`;
+            // TODO - add some sort of world.getCiv that can take an undefined ID to make this less ugly. Also, TODO make a translate string for 'Free City'.
+            tileOwner.innerText = `${translate('tile.info.owner')}: ${tile.owner.name} (${tile.owner.civID ? world.civs[(_b = tile.owner.civID) === null || _b === void 0 ? void 0 : _b.subID].name : 'Free City'})`;
             this.elements.tileInfoMenu.appendChild(tileOwner);
         }
         this.root.appendChild(this.elements.tileInfoMenu);

--- a/client/dist/world.js
+++ b/client/dist/world.js
@@ -161,14 +161,14 @@ class World {
             return domainID.type === DomainType.CITY && domain.id === domainID.subID;
         }
     }
-    controlsTile(tile) {
+    playerControlsTile(tile) {
         const { owner } = tile;
         if (this.player.leaderID === null || !owner)
             return false;
         const leader = this.leaders[this.player.leaderID];
         return leader.domains.some(domain => this.domainMatchesID(domain, makeCityID(owner.id)) || (owner.civID && this.domainMatchesID(domain, owner.civID)));
     }
-    controlsUnit(unit) {
+    playerControlsUnit(unit) {
         if (this.player.leaderID === null)
             return false;
         const leader = this.leaders[this.player.leaderID];
@@ -183,7 +183,7 @@ class World {
             tile.type === 'frozen_river');
     }
     canBuildOn(tile) {
-        return (this.controlsTile(tile) &&
+        return (this.playerControlsTile(tile) &&
             !this.isOcean(tile) &&
             tile.type !== 'mountain');
     }
@@ -219,7 +219,7 @@ class World {
             for (const adjPos of this.getNeighbors(atPos)) {
                 const tile = this.getTile(adjPos);
                 const atTile = this.getTile(atPos);
-                if (tile.unit && this.controlsUnit(tile.unit))
+                if (tile.unit && this.playerControlsUnit(tile.unit))
                     continue;
                 const adjDirection = this.getDirection(adjPos, atPos);
                 const atDirection = this.getDirection(atPos, adjPos);

--- a/client/dist/world.js
+++ b/client/dist/world.js
@@ -70,6 +70,7 @@ const makeCivID = (id) => ({
     type: DomainType.CIVILIZATION,
 });
 const isCiv = (domain) => (domain.templateID !== undefined);
+const compareDomainIDs = (a, b) => a !== undefined && b !== undefined && a.type === b.type && a.subID === b.subID;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class World {
     constructor() {

--- a/client/dist/world.js
+++ b/client/dist/world.js
@@ -535,8 +535,6 @@ class World {
                     if (player.leaderID !== null)
                         ui.leaders[player.leaderID] = Object.assign(Object.assign({}, player), { name: playerName });
                 }
-                for (const civTemplateID in civPool) {
-                }
                 ui.setView('civPicker');
                 ui.showCivPicker(civPickerFn, this.player);
             };
@@ -548,6 +546,9 @@ class World {
             };
             this.on.update.leaderID = (leaderID) => {
                 this.player.leaderID = leaderID;
+            };
+            this.on.update.leaderUpdate = (leaderID, leaderData) => {
+                this.leaders[leaderID] = leaderData;
             };
             this.on.update.tradersList = (tradeRoutes) => {
                 this.tradeRoutes = tradeRoutes;

--- a/client/dist/world.js
+++ b/client/dist/world.js
@@ -7,6 +7,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var DomainType;
+(function (DomainType) {
+    DomainType[DomainType["CIVILIZATION"] = 0] = "CIVILIZATION";
+    DomainType[DomainType["CITY"] = 1] = "CITY";
+})(DomainType || (DomainType = {}));
 var PromotionClass;
 (function (PromotionClass) {
     PromotionClass[PromotionClass["CIVILLIAN"] = 0] = "CIVILLIAN";
@@ -56,6 +61,15 @@ const getCoordsDial = ({ x, y }) => {
             { x: x - 1, y: y },
         ];
 };
+const makeCityID = (id) => ({
+    subID: id,
+    type: DomainType.CITY,
+});
+const makeCivID = (id) => ({
+    subID: id,
+    type: DomainType.CIVILIZATION,
+});
+const isCiv = (domain) => (domain.templateID !== undefined);
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class World {
     constructor() {
@@ -74,9 +88,10 @@ class World {
         };
         this.listeners = {};
         this.civs = {};
+        this.leaders = {};
         this.player = {
             name: null,
-            civID: null,
+            leaderID: null,
         };
         this.tradeRoutes = [];
     }
@@ -137,6 +152,27 @@ class World {
             return x1 + 1;
         return x1;
     }
+    domainMatchesID(domain, domainID) {
+        if (isCiv(domain)) {
+            return domainID.type === DomainType.CIVILIZATION && domain.id === domainID.subID;
+        }
+        else {
+            return domainID.type === DomainType.CITY && domain.id === domainID.subID;
+        }
+    }
+    controlsTile(tile) {
+        const { owner } = tile;
+        if (this.player.leaderID === null || !owner)
+            return false;
+        const leader = this.leaders[this.player.leaderID];
+        return leader.domains.some(domain => this.domainMatchesID(domain, makeCityID(owner.id)) || (owner.civID && this.domainMatchesID(domain, owner.civID)));
+    }
+    controlsUnit(unit) {
+        if (this.player.leaderID === null)
+            return false;
+        const leader = this.leaders[this.player.leaderID];
+        return leader.domains.some(domain => this.domainMatchesID(domain, unit.domainID));
+    }
     isOcean(tile) {
         return (tile.type === 'ocean' ||
             tile.type === 'frozen_ocean');
@@ -146,8 +182,7 @@ class World {
             tile.type === 'frozen_river');
     }
     canBuildOn(tile) {
-        var _a;
-        return (((_a = tile.owner) === null || _a === void 0 ? void 0 : _a.civID) === this.player.civID &&
+        return (this.controlsTile(tile) &&
             !this.isOcean(tile) &&
             tile.type !== 'mountain');
     }
@@ -183,7 +218,7 @@ class World {
             for (const adjPos of this.getNeighbors(atPos)) {
                 const tile = this.getTile(adjPos);
                 const atTile = this.getTile(atPos);
-                if (tile.unit && tile.unit.civID === this.player.civID)
+                if (tile.unit && this.controlsUnit(tile.unit))
                     continue;
                 const adjDirection = this.getDirection(adjPos, atPos);
                 const atDirection = this.getDirection(atPos, adjPos);
@@ -390,9 +425,9 @@ class World {
                     ['ready', [isReady]],
                 ]);
             };
-            const civPickerFn = (leaderID) => {
+            const civPickerFn = (civTemplateID) => {
                 this.sendActions([
-                    ['setLeader', [leaderID]],
+                    ['selectCiv', [civTemplateID]],
                 ]);
             };
             this.on.update.debug = (data) => {
@@ -489,25 +524,30 @@ class World {
                     this.unitPositions.splice(index, 1);
                 camera.deselectUnit(this);
             };
-            this.on.update.leaderPool = (leaders, takenLeaders, players) => {
-                ui.leaderPool = leaders;
-                ui.takenLeaders = takenLeaders;
+            this.on.update.civPool = (civPool, civTemplates, players) => {
+                ui.civPool = civPool;
+                ui.civTemplates = civTemplates;
                 ui.players = {};
-                ui.civs = {};
+                ui.leaders = {};
                 for (const playerName in players) {
                     const player = players[playerName];
                     ui.players[playerName] = Object.assign(Object.assign({}, player), { name: playerName });
-                    if (player.civID !== null)
-                        ui.civs[player.civID] = Object.assign(Object.assign({}, player), { name: playerName });
+                    if (player.leaderID !== null)
+                        ui.leaders[player.leaderID] = Object.assign(Object.assign({}, player), { name: playerName });
+                }
+                for (const civTemplateID in civPool) {
                 }
                 ui.setView('civPicker');
                 ui.showCivPicker(civPickerFn, this.player);
             };
+            this.on.update.leaderData = (leaders) => {
+                this.leaders = leaders;
+            };
             this.on.update.civData = (civs) => {
                 this.civs = civs;
             };
-            this.on.update.civID = (civID) => {
-                this.player.civID = civID;
+            this.on.update.leaderID = (leaderID) => {
+                this.player.leaderID = leaderID;
             };
             this.on.update.tradersList = (tradeRoutes) => {
                 this.tradeRoutes = tradeRoutes;

--- a/client/src/camera.ts
+++ b/client/src/camera.ts
@@ -1,3 +1,4 @@
+const DEFAULT_COLOR = '#333';
 const [TILE_WIDTH, TILE_HEIGHT] = [28, 26];
 const X_TILE_SPACING = TILE_WIDTH * 3/4;
 const Y_TILE_SPACING = TILE_HEIGHT / 2;
@@ -204,7 +205,7 @@ class Camera {
     if (unit.cloaked) ctx.globalAlpha = 0.5;
 
     // Unit Color Background
-    ctx.fillStyle = civs[unit.civID]?.color ?? (unit.isBarbarian ? '#F00': '#333');
+    ctx.fillStyle = unit.domainID.type === DomainType.CIVILIZATION ? (civs[unit.domainID.subID]?.color ?? DEFAULT_COLOR) : DEFAULT_COLOR;
     ctx.beginPath();
     ctx.rect(
       (-camX + ((x - (width / 2)) * X_TILE_SPACING) + 6.5) * zoom,
@@ -377,7 +378,7 @@ class Camera {
             ctx.beginPath();
             ctx.lineWidth = margin * 2;
             ctx.lineCap='square';
-            ctx.strokeStyle = world.civs[tile.owner.civID].color;
+            ctx.strokeStyle = tile.owner.civID ? world.civs[tile.owner.civID.subID].color : DEFAULT_COLOR;
             ctx.moveTo(leftX + leftCapXOffset + margin, topY + margin);
             for (let i = 0; i < neighbors.length; i++) {
               const neighbor = world.getTile(neighbors[i]);
@@ -385,7 +386,7 @@ class Camera {
               else if (neighbor.owner?.civID === tile.owner.civID) ctx.moveTo(...positions[i]);
               else ctx.lineTo(...positions[i]);
             }
-            if (tile.owner.civID === world.player.civID) ctx.setLineDash([5 * zoom, 5 * zoom]);
+            if (world.controlsTile(tile)) ctx.setLineDash([5 * zoom, 5 * zoom]);
             ctx.stroke();
             ctx.setLineDash([]);
           }
@@ -423,7 +424,7 @@ class Camera {
 
               if (this.selectedUnitPos) {
                 const selectedUnit = world.getTile(this.selectedUnitPos).unit;
-                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && tile.unit.civID !== world.player.civID) {
+                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && !world.controlsUnit(tile.unit)) {
                   world.attack(this.selectedUnitPos, {x, y}, selectedUnit as RangedUnit);
                 } else if (world.posIndex({x, y}) in this.highlightedTiles) {
                   world.moveUnit(this.selectedUnitPos, {x, y}, this.highlightedTiles, !!tile.unit);
@@ -441,7 +442,7 @@ class Camera {
               TILE_HEIGHT * zoom
             );
 
-            if (tile.unit && this.mouseDownTime === 1 && tile.unit.civID === world.player.civID && ui.turnActive) {
+            if (tile.unit && this.mouseDownTime === 1 && world.controlsUnit(tile.unit) && ui.turnActive) {
               console.log(tile.unit);
               this.selectUnit(world, { x, y }, tile.unit);
             }

--- a/client/src/camera.ts
+++ b/client/src/camera.ts
@@ -383,7 +383,7 @@ class Camera {
             for (let i = 0; i < neighbors.length; i++) {
               const neighbor = world.getTile(neighbors[i]);
               if (!neighbor) ctx.moveTo(...positions[i]);
-              else if (neighbor.owner?.civID === tile.owner.civID) ctx.moveTo(...positions[i]);
+              else if (compareDomainIDs(neighbor.owner?.civID, tile.owner.civID) || neighbor.owner?.id === tile.owner.id) ctx.moveTo(...positions[i]);
               else ctx.lineTo(...positions[i]);
             }
             if (world.controlsTile(tile)) ctx.setLineDash([5 * zoom, 5 * zoom]);

--- a/client/src/camera.ts
+++ b/client/src/camera.ts
@@ -386,7 +386,7 @@ class Camera {
               else if (compareDomainIDs(neighbor.owner?.civID, tile.owner.civID) || neighbor.owner?.id === tile.owner.id) ctx.moveTo(...positions[i]);
               else ctx.lineTo(...positions[i]);
             }
-            if (world.controlsTile(tile)) ctx.setLineDash([5 * zoom, 5 * zoom]);
+            if (world.playerControlsTile(tile)) ctx.setLineDash([5 * zoom, 5 * zoom]);
             ctx.stroke();
             ctx.setLineDash([]);
           }
@@ -424,7 +424,7 @@ class Camera {
 
               if (this.selectedUnitPos) {
                 const selectedUnit = world.getTile(this.selectedUnitPos).unit;
-                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && !world.controlsUnit(tile.unit)) {
+                if (tile.unit && selectedUnit.promotionClass === PromotionClass.RANGED && !world.playerControlsUnit(tile.unit)) {
                   world.attack(this.selectedUnitPos, {x, y}, selectedUnit as RangedUnit);
                 } else if (world.posIndex({x, y}) in this.highlightedTiles) {
                   world.moveUnit(this.selectedUnitPos, {x, y}, this.highlightedTiles, !!tile.unit);
@@ -442,7 +442,7 @@ class Camera {
               TILE_HEIGHT * zoom
             );
 
-            if (tile.unit && this.mouseDownTime === 1 && world.controlsUnit(tile.unit) && ui.turnActive) {
+            if (tile.unit && this.mouseDownTime === 1 && world.playerControlsUnit(tile.unit) && ui.turnActive) {
               console.log(tile.unit);
               this.selectUnit(world, { x, y }, tile.unit);
             }

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -609,8 +609,8 @@ class UI {
 
     if (tile.owner) {
       const tileOwner = this.createElement('span', {className: 'infoSpan'});
-      // TODO
-      // tileOwner.innerText = `${translate('tile.info.owner')}: ${world.civs[tile.owner.civID].leader.name}`;
+      // TODO - add some sort of world.getCiv that can take an undefined ID to make this less ugly. Also, TODO make a translate string for 'Free City'.
+      tileOwner.innerText = `${translate('tile.info.owner')}: ${tile.owner.name} (${tile.owner.civID ? world.civs[tile.owner.civID?.subID].name : 'Free City'})`;
       this.elements.tileInfoMenu.appendChild(tileOwner);
     }
 

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -1,12 +1,3 @@
-interface Leader {
-  id: number;
-  color: string;
-  textColor: string;
-  secondaryColor: string;
-  name: string;
-  civID: number;
-}
-
 type ElementOptions = {
   innerText?: string;
   src?: string;
@@ -92,10 +83,10 @@ class UI {
 
   root: HTMLElement;
   elements: { [key: string]: HTMLElement };
-  leaderPool: Leader[];
-  takenLeaders: Leader[];
+  civPool: {[civTemplateID: number]: number | null};
+  civTemplates: CivTemplate[];
   players: {[playerName: string]: Player};
-  civs: {[civID: string]: Player};
+  leaders: {[leaderID: string]: Player};
   turnActive: boolean;
   buttons: { [key: string]: Button };
   textInputs: { [key: string]: TextInput };
@@ -118,10 +109,10 @@ class UI {
       tileInfoMenu: this.createElement('div', {className: 'tileInfoMenu'}),
       sidebarMenu: this.createElement('div', {className: 'sidebarMenu'}),
     };
-    this.leaderPool = [];
-    this.takenLeaders = [];
+    this.civPool = {};
+    this.civTemplates = [];
     this.players = {};
-    this.civs = {};
+    this.leaders = {};
     this.turnActive = false;
 
     this.buttons = {
@@ -233,12 +224,12 @@ class UI {
     return element;
   }
 
-  createCivItem(leader: Leader): HTMLElement {
+  createCivItem(civTemplate: CivTemplate, selectedBy: Leader | null): HTMLElement {
     const civItem = this.createElement('li', {className: 'civItem'});
-    civItem.style.backgroundColor = leader.color;
-    civItem.style.color = leader.textColor;
+    civItem.style.backgroundColor = civTemplate.color;
+    civItem.style.color = civTemplate.textColor;
     const nameText = this.createElement('span');
-    nameText.innerHTML = `${leader.name}` + (leader.civID !== null ? ` - ${translate('menu.civ.selected_by')} ${this.civs[leader.civID].name}` : '');
+    nameText.innerHTML = `${civTemplate.name}` + (selectedBy !== null ? ` - ${translate('menu.civ.selected_by')} ${this.leaders[selectedBy.id].name}` : '');
     civItem.appendChild(nameText);
     return civItem;
   }
@@ -312,25 +303,25 @@ class UI {
     }
   }
 
-  showCivPicker(callback: (leaderID: number) => void, self: Player): void {
+  showCivPicker(callback: (civTemplateID: number) => void, self: Player): void {
     this.elements.civPicker.innerHTML = '';
     const selectedLeaderSlot = this.createElement('div', {className: 'selectedLeader'});
     this.elements.civPicker.appendChild(selectedLeaderSlot);
-    for (let i = 0; i < this.leaderPool.length; i++) {
-      const leader = this.leaderPool[i];
-      const civItem = this.createCivItem(leader);
-      civItem.onclick = () => {
-        callback(leader.id);
-      };
-      this.elements.civPicker.appendChild(civItem);
-    }
-    for (let i = 0; i < this.takenLeaders.length; i++) {
-      const leader = this.takenLeaders[i];
-      const civItem = this.createCivItem(leader);
-      civItem.onclick = () => {
-        alert(translate('error.civ_taken'))
-      };
-      if (leader.civID === self.civID) {
+    for (let civTemplateID = 0; civTemplateID < this.civTemplates.length; civTemplateID++) {
+      const civTemplate = this.civTemplates[civTemplateID];
+      const leaderID: number | null = this.civPool[civTemplateID];
+      const leader: Leader | null = leaderID !== null ? world.leaders[leaderID] : null;
+      const civItem = this.createCivItem(civTemplate, leader);
+      if (leader) {
+        civItem.onclick = () => {
+          alert(translate('error.civ_taken'))
+        };
+      } else {
+        civItem.onclick = () => {
+          callback(civTemplateID);
+        };
+      }
+      if (leader && leader.id === self.leaderID) {
         selectedLeaderSlot.appendChild(civItem);
       } else {
         this.elements.civPicker.appendChild(civItem);
@@ -618,7 +609,8 @@ class UI {
 
     if (tile.owner) {
       const tileOwner = this.createElement('span', {className: 'infoSpan'});
-      tileOwner.innerText = `${translate('tile.info.owner')}: ${world.civs[tile.owner.civID].leader.name}`;
+      // TODO
+      // tileOwner.innerText = `${translate('tile.info.owner')}: ${world.civs[tile.owner.civID].leader.name}`;
       this.elements.tileInfoMenu.appendChild(tileOwner);
     }
 

--- a/client/src/world.ts
+++ b/client/src/world.ts
@@ -728,9 +728,6 @@ class World {
         ui.players[playerName] = { ...player, name: playerName };
         if (player.leaderID !== null) ui.leaders[player.leaderID] = { ...player, name: playerName };
       }
-      for (const civTemplateID in civPool) {
-        
-      }
       ui.setView('civPicker');
       ui.showCivPicker(civPickerFn, this.player);
     };
@@ -745,6 +742,10 @@ class World {
 
     this.on.update.leaderID = (leaderID: number): void => {
       this.player.leaderID = leaderID;
+    };
+
+    this.on.update.leaderUpdate = (leaderID: number, leaderData: Leader): void => {
+      this.leaders[leaderID] = leaderData;
     };
 
     this.on.update.tradersList = (tradeRoutes: TradeRoute[]) => {

--- a/client/src/world.ts
+++ b/client/src/world.ts
@@ -1,11 +1,51 @@
 interface Civ {
+  id: number;
+  templateID: number;
   color: string;
-  leader: Leader;
+  textColor: string;
+  secondaryColor: string;
+  name: string;
+  leaderID: number | null;
+}
+
+type City = {
+  id: number,
+  civID?: CivDomainID,
+  name: string,
+  isBarbarian: boolean,
+};
+
+interface CivTemplate {
+  color: string;
+  name: string;
+  textColor: string;
+  startingKnowledge?: { [knowledgeName: string]: number };
+}
+
+enum DomainType {
+  CIVILIZATION,
+  CITY,
+}
+
+type DomainID = {
+  subID: number,
+  type: DomainType,
+};
+
+type SpecificTypeDomainID<T extends DomainType> = DomainID & {
+  type: T;
+};
+type CivDomainID = SpecificTypeDomainID<DomainType.CIVILIZATION>;
+type CityDomainID = SpecificTypeDomainID<DomainType.CITY>;
+
+interface Leader {
+  id: number;
+  domains: (Civ | City)[];
 }
 
 interface Player {
   name: string | null;
-  civID: number | null;
+  leaderID: number | null;
 }
 
 interface WorldEventHandlerMap {
@@ -22,7 +62,7 @@ interface Unit {
   type: string;
   hp: number;
   movement: number;
-  civID: number;
+  domainID: DomainID,
   promotionClass: PromotionClass;
   knowledge: KnowledgeMap;
   cloaked?: boolean;
@@ -104,11 +144,7 @@ interface Tile {
   movementCost: MovementCost;
   unit: Unit;
   yield: Yield,
-  owner?: {
-    civID: number,
-    name: string,
-    isBarbarian: boolean,
-  };
+  owner?: City;
   visible: boolean;
   walls: Wall[];
 }
@@ -165,6 +201,17 @@ const getCoordsDial = ({x, y}: Coords): Coords[] => {
   ];
 };
 
+const makeCityID = (id: number): CityDomainID => ({
+  subID: id,
+  type: DomainType.CITY,
+});
+const makeCivID = (id: number): CivDomainID => ({
+  subID: id,
+  type: DomainType.CIVILIZATION,
+});
+
+const isCiv = (domain: (Civ | City)): domain is Civ => ((domain as Civ).templateID !== undefined);
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class World {
   tiles: Tile[];
@@ -178,7 +225,9 @@ class World {
   socketDidOpen: boolean;
   on: { update: WorldEventHandlerMap, error: WorldEventHandlerMap, event: WorldEventHandlerMap };
   listeners: { [name: string]: ((...args: any) => void) | null };
-  civs: { [key: string]: Civ };
+  civs: { [subID: number]: Civ };
+  cities: { [subID: number]: City };
+  leaders: { [key: string]: Leader };
   player: Player;
   tradeRoutes: TradeRoute[];
   constructor() {
@@ -197,9 +246,10 @@ class World {
     };
     this.listeners = {};
     this.civs = {};
+    this.leaders = {};
     this.player = {
       name: null,
-      civID: null,
+      leaderID: null,
     };
     this.tradeRoutes = [];
   }
@@ -264,6 +314,27 @@ class World {
     return x1;
   }
 
+  domainMatchesID(domain: (City | Civ), domainID: DomainID): boolean {
+    if (isCiv(domain)) {
+      return domainID.type === DomainType.CIVILIZATION && domain.id === domainID.subID;
+    } else {
+      return domainID.type === DomainType.CITY && domain.id === domainID.subID;
+    }
+  }
+
+  controlsTile(tile: Tile): boolean {
+    const { owner } = tile;
+    if (this.player.leaderID === null || !owner) return false;
+    const leader = this.leaders[this.player.leaderID];
+    return leader.domains.some(domain => this.domainMatchesID(domain, makeCityID(owner.id)) || (owner.civID && this.domainMatchesID(domain, owner.civID)));
+  }
+
+  controlsUnit(unit: Unit): boolean {
+    if (this.player.leaderID === null) return false;
+    const leader = this.leaders[this.player.leaderID];
+    return leader.domains.some(domain => this.domainMatchesID(domain, unit.domainID));
+  }
+
   isOcean(tile: Tile): boolean {
     return (
       tile.type === 'ocean' ||
@@ -281,7 +352,7 @@ class World {
 
   canBuildOn(tile: Tile): boolean {
     return (
-      tile.owner?.civID === this.player.civID &&
+      this.controlsTile(tile) &&
       !this.isOcean(tile) &&
       tile.type !== 'mountain'
     );
@@ -329,7 +400,7 @@ class World {
 
         const tile = this.getTile(adjPos);
         const atTile = this.getTile(atPos);
-        if (tile.unit && tile.unit.civID === this.player.civID) continue;
+        if (tile.unit && this.controlsUnit(tile.unit)) continue;
         const adjDirection = this.getDirection(adjPos, atPos);
         const atDirection = this.getDirection(atPos, adjPos);
         if (tile.walls[adjDirection] && tile.walls[adjDirection].type !== WallType.OPEN_GATE) continue;
@@ -538,9 +609,9 @@ class World {
       ]);
     };
 
-    const civPickerFn = (leaderID: number): void => {
+    const civPickerFn = (civTemplateID: number): void => {
       this.sendActions([
-        ['setLeader', [leaderID]],
+        ['selectCiv', [civTemplateID]],
       ]);
     };
 
@@ -647,26 +718,33 @@ class World {
       camera.deselectUnit(this);
     };
 
-    this.on.update.leaderPool = (leaders: Leader[], takenLeaders: Leader[], players: {[playerName: string]: Player}): void => {
-      ui.leaderPool = leaders;
-      ui.takenLeaders = takenLeaders;
+    this.on.update.civPool = (civPool: {[civTemplateID: number]: number | null}, civTemplates: CivTemplate[], players: {[playerName: string]: Player}): void => {
+      ui.civPool = civPool;
+      ui.civTemplates = civTemplates;
       ui.players = {};
-      ui.civs = {};
+      ui.leaders = {};
       for (const playerName in players) {
         const player = players[playerName];
         ui.players[playerName] = { ...player, name: playerName };
-        if (player.civID !== null) ui.civs[player.civID] = { ...player, name: playerName };
+        if (player.leaderID !== null) ui.leaders[player.leaderID] = { ...player, name: playerName };
+      }
+      for (const civTemplateID in civPool) {
+        
       }
       ui.setView('civPicker');
       ui.showCivPicker(civPickerFn, this.player);
+    };
+
+    this.on.update.leaderData = (leaders: { [key: string]: Leader }) => {
+      this.leaders = leaders;
     };
 
     this.on.update.civData = (civs: { [key: string]: Civ }) => {
       this.civs = civs;
     };
 
-    this.on.update.civID = (civID: number): void => {
-      this.player.civID = civID;
+    this.on.update.leaderID = (leaderID: number): void => {
+      this.player.leaderID = leaderID;
     };
 
     this.on.update.tradersList = (tradeRoutes: TradeRoute[]) => {

--- a/client/src/world.ts
+++ b/client/src/world.ts
@@ -211,6 +211,7 @@ const makeCivID = (id: number): CivDomainID => ({
 });
 
 const isCiv = (domain: (Civ | City)): domain is Civ => ((domain as Civ).templateID !== undefined);
+const compareDomainIDs = (a?: DomainID, b?: DomainID): boolean => a !== undefined && b !== undefined && a.type === b.type && a.subID === b.subID;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class World {

--- a/client/src/world.ts
+++ b/client/src/world.ts
@@ -323,14 +323,14 @@ class World {
     }
   }
 
-  controlsTile(tile: Tile): boolean {
+  playerControlsTile(tile: Tile): boolean {
     const { owner } = tile;
     if (this.player.leaderID === null || !owner) return false;
     const leader = this.leaders[this.player.leaderID];
     return leader.domains.some(domain => this.domainMatchesID(domain, makeCityID(owner.id)) || (owner.civID && this.domainMatchesID(domain, owner.civID)));
   }
 
-  controlsUnit(unit: Unit): boolean {
+  playerControlsUnit(unit: Unit): boolean {
     if (this.player.leaderID === null) return false;
     const leader = this.leaders[this.player.leaderID];
     return leader.domains.some(domain => this.domainMatchesID(domain, unit.domainID));
@@ -353,7 +353,7 @@ class World {
 
   canBuildOn(tile: Tile): boolean {
     return (
-      this.controlsTile(tile) &&
+      this.playerControlsTile(tile) &&
       !this.isOcean(tile) &&
       tile.type !== 'mountain'
     );
@@ -401,7 +401,7 @@ class World {
 
         const tile = this.getTile(adjPos);
         const atTile = this.getTile(atPos);
-        if (tile.unit && this.controlsUnit(tile.unit)) continue;
+        if (tile.unit && this.playerControlsUnit(tile.unit)) continue;
         const adjDirection = this.getDirection(adjPos, atPos);
         const atDirection = this.getDirection(atPos, adjPos);
         if (tile.walls[adjDirection] && tile.walls[adjDirection].type !== WallType.OPEN_GATE) continue;

--- a/server/src/game/civilization.ts
+++ b/server/src/game/civilization.ts
@@ -1,77 +1,85 @@
-import { Leader, LeaderData } from './leader';
-import { Unit } from './map/tile/unit';
-import { Coords } from './world';
+import { KnowledgeMap } from './map/tile/knowledge';
+
+const DEFAULT_START_KNOWLEDGE = {
+  'start': 100,
+  'food_0': 100,
+  'military_0': 100,
+  'science_1': 100,
+}
+
+export const civTemplates = [
+  { color: '#820000', textColor: '#ccc', name: 'Rokun', startingKnowledge: { 'science_1': 0, 'military_1': 100 } }, // RICH RED
+  { color: '#0a2ead', textColor: '#ccc', name: 'Azura' }, // BLUE
+  { color: '#03a300', textColor: '#222', name: 'Vertos' }, // GREEN
+  { color: '#bd9a02', textColor: '#222', name: 'Solei' }, // SAND YELLOW
+  { color: '#560e8a', textColor: '#ccc', name: 'Imperius' }, // ROYAL PURPLE
+  { color: '#bd7400', textColor: '#333', name: 'Baranog' }, // ORANGE
+];
 
 export interface CivilizationData {
-  color?: string;
-  leader?: LeaderData;
+  id: number;
+  color: string;
+  textColor: string;
+  secondaryColor: string;
+  name: string;
+  leaderID: number | null;
 }
 
 export class Civilization {
-  units: Unit[];
-  leader?: Leader;
-  turnActive: boolean;
-  turnFinished: boolean;
+  private id: number;
+  private color: string;
+  private textColor: string;
+  private secondaryColor: string;
+  private name: string;
+  private leaderID: number | null;
 
-  constructor() {
-    this.units = [];
-    this.turnActive = false;
-    this.turnFinished = false;
-  }
+  public startingKnowledge: KnowledgeMap;
 
-  export() {
-    return {
-      units: this.units.map(unit => unit.export()),
-      turnActive: this.turnActive,
-      turnFinished: this.turnFinished,
+  constructor(id: number) {
+    const { color, textColor, name, startingKnowledge } = civTemplates[id];
+    this.id = id;
+    this.color = color;
+    this.textColor = textColor;
+    this.secondaryColor = color;
+    this.name = name;
+    this.leaderID = null;
+
+    this.startingKnowledge = {
+      ...DEFAULT_START_KNOWLEDGE,
+      ...startingKnowledge,
     };
   }
 
   static import(data: any): Civilization {
-    const civ =  new Civilization();
-    // civ.units = data.units.map(unitData => Unit.import(unitData));
-    civ.turnActive = data.turnActive;
-    civ.turnFinished = data.turnFinished;
+    const civ = new Civilization(data.id);
+    civ.color = data.color;
+    civ.textColor = data.textColor;
+    civ.secondaryColor = data.secondaryColor;
+    civ.name = data.name;
+    civ.leaderID = null;
     return civ;
   }
 
+  select(leaderID: number): void {
+    this.leaderID = leaderID;
+  }
+
+  unselect(): void {
+    this.leaderID = null;
+  }
+
+  hasLeader(): boolean {
+    return this.leaderID !== null;
+  }
+
   getData(): CivilizationData {
-    const leaderData = this.leader?.getData();
     return {
-      color: leaderData?.color,
-      leader: leaderData,
-    }
-  }
-
-  newTurn() {
-    this.turnActive = true;
-    this.turnFinished = false;
-
-    for (const unit of this.units) {
-      unit.newTurn();
-    }
-  }
-
-  endTurn() {
-    this.turnActive = false;
-  }
-
-  getUnits(): Unit[] {
-    return this.units;
-  }
-
-  getUnitPositions(): Coords[] {
-    return this.units.map(unit => unit.coords);
-  }
-
-  addUnit(unit: Unit): void {
-    this.units.push(unit);
-  }
-
-  removeUnit(unit: Unit): void {
-    const unitIndex = this.units.indexOf(unit);
-    if (unitIndex > -1) {
-      this.units.splice(unitIndex, 1);
-    }
+      id: this.id,
+      color: this.color,
+      textColor: this.textColor,
+      secondaryColor: this.secondaryColor,
+      name: this.name,
+      leaderID: this.leaderID,
+    };
   }
 }

--- a/server/src/game/civilization.ts
+++ b/server/src/game/civilization.ts
@@ -55,14 +55,12 @@ export class Civilization extends Domain {
 
   export() {
     return {
-      id: this.id,
+      ...super.baseExport(),
       templateID: this.templateID,
       color: this.color,
       textColor: this.textColor,
       secondaryColor: this.secondaryColor,
       name: this.name,
-      leader: this.leader,
-      units: this.units.map(unit => unit.export()),
     };
   }
 
@@ -72,8 +70,6 @@ export class Civilization extends Domain {
     civ.textColor = data.textColor;
     civ.secondaryColor = data.secondaryColor;
     civ.name = data.name;
-    civ.leader = null;
-    civ.units = data.units.map((unitData: any) => Unit.import(unitData));
     return civ;
   }
 

--- a/server/src/game/civilization.ts
+++ b/server/src/game/civilization.ts
@@ -1,4 +1,6 @@
 import { KnowledgeMap } from './map/tile/knowledge';
+import { Unit } from './map/tile/unit';
+import { Coords } from './world';
 
 const DEFAULT_START_KNOWLEDGE = {
   'start': 100,
@@ -33,6 +35,7 @@ export class Civilization {
   private name: string;
   private leaderID: number | null;
 
+  public units: Unit[];
   public startingKnowledge: KnowledgeMap;
 
   constructor(id: number) {
@@ -44,9 +47,22 @@ export class Civilization {
     this.name = name;
     this.leaderID = null;
 
+    this.units = [];
     this.startingKnowledge = {
       ...DEFAULT_START_KNOWLEDGE,
       ...startingKnowledge,
+    };
+  }
+
+  export() {
+    return {
+      id: this.id,
+      color: this.color,
+      textColor: this.textColor,
+      secondaryColor: this.secondaryColor,
+      name: this.name,
+      leaderID: this.leaderID,
+      units: this.units.map(unit => unit.export()),
     };
   }
 
@@ -57,6 +73,7 @@ export class Civilization {
     civ.secondaryColor = data.secondaryColor;
     civ.name = data.name;
     civ.leaderID = null;
+    civ.units = data.units.map((unitData: any) => Unit.import(unitData));
     return civ;
   }
 
@@ -81,5 +98,24 @@ export class Civilization {
       name: this.name,
       leaderID: this.leaderID,
     };
+  }
+
+  getUnits(): Unit[] {
+    return this.units;
+  }
+
+  getUnitPositions(): Coords[] {
+    return this.units.map(unit => unit.coords);
+  }
+
+  addUnit(unit: Unit): void {
+    this.units.push(unit);
+  }
+
+  removeUnit(unit: Unit): void {
+    const unitIndex = this.units.indexOf(unit);
+    if (unitIndex > -1) {
+      this.units.splice(unitIndex, 1);
+    }
   }
 }

--- a/server/src/game/civilization.ts
+++ b/server/src/game/civilization.ts
@@ -1,3 +1,4 @@
+import { Domain, DomainID, DomainType, Leader } from './leader';
 import { KnowledgeMap } from './map/tile/knowledge';
 import { Unit } from './map/tile/unit';
 import { Coords } from './world';
@@ -25,33 +26,27 @@ export interface CivilizationData {
   textColor: string;
   secondaryColor: string;
   name: string;
-  leaderID: number | null;
+  leader: Leader | null;
 }
 
-export class Civilization {
-  public id: number;
-
+export class Civilization extends Domain {
   private templateID: number;
   private color: string;
   private textColor: string;
   private secondaryColor: string;
   private name: string;
-  private leaderID: number | null;
 
-  public units: Unit[];
   public startingKnowledge: KnowledgeMap;
 
   constructor(id: number, templateID: number) {
-    this.id = id;
+    super(id, DomainType.CIVILIZATION);
     const { color, textColor, name, startingKnowledge } = civTemplates[templateID];
     this.templateID = templateID;
     this.color = color;
     this.textColor = textColor;
     this.secondaryColor = color;
     this.name = name;
-    this.leaderID = null;
 
-    this.units = [];
     this.startingKnowledge = {
       ...DEFAULT_START_KNOWLEDGE,
       ...startingKnowledge,
@@ -66,7 +61,7 @@ export class Civilization {
       textColor: this.textColor,
       secondaryColor: this.secondaryColor,
       name: this.name,
-      leaderID: this.leaderID,
+      leader: this.leader,
       units: this.units.map(unit => unit.export()),
     };
   }
@@ -77,21 +72,9 @@ export class Civilization {
     civ.textColor = data.textColor;
     civ.secondaryColor = data.secondaryColor;
     civ.name = data.name;
-    civ.leaderID = null;
+    civ.leader = null;
     civ.units = data.units.map((unitData: any) => Unit.import(unitData));
     return civ;
-  }
-
-  select(leaderID: number): void {
-    this.leaderID = leaderID;
-  }
-
-  unselect(): void {
-    this.leaderID = null;
-  }
-
-  hasLeader(): boolean {
-    return this.leaderID !== null;
   }
 
   getData(): CivilizationData {
@@ -102,26 +85,7 @@ export class Civilization {
       textColor: this.textColor,
       secondaryColor: this.secondaryColor,
       name: this.name,
-      leaderID: this.leaderID,
+      leader: this.leader,
     };
-  }
-
-  getUnits(): Unit[] {
-    return this.units;
-  }
-
-  getUnitPositions(): Coords[] {
-    return this.units.map(unit => unit.coords);
-  }
-
-  addUnit(unit: Unit): void {
-    this.units.push(unit);
-  }
-
-  removeUnit(unit: Unit): void {
-    const unitIndex = this.units.indexOf(unit);
-    if (unitIndex > -1) {
-      this.units.splice(unitIndex, 1);
-    }
   }
 }

--- a/server/src/game/civilization.ts
+++ b/server/src/game/civilization.ts
@@ -19,6 +19,7 @@ export const civTemplates = [
 ];
 
 export interface CivilizationData {
+  id: number;
   templateID: number;
   color: string;
   textColor: string;
@@ -28,6 +29,8 @@ export interface CivilizationData {
 }
 
 export class Civilization {
+  public id: number;
+
   private templateID: number;
   private color: string;
   private textColor: string;
@@ -38,7 +41,8 @@ export class Civilization {
   public units: Unit[];
   public startingKnowledge: KnowledgeMap;
 
-  constructor(templateID: number) {
+  constructor(id: number, templateID: number) {
+    this.id = id;
     const { color, textColor, name, startingKnowledge } = civTemplates[templateID];
     this.templateID = templateID;
     this.color = color;
@@ -56,6 +60,7 @@ export class Civilization {
 
   export() {
     return {
+      id: this.id,
       templateID: this.templateID,
       color: this.color,
       textColor: this.textColor,
@@ -67,7 +72,7 @@ export class Civilization {
   }
 
   static import(data: any): Civilization {
-    const civ = new Civilization(data.templateID);
+    const civ = new Civilization(data.id, data.templateID);
     civ.color = data.color;
     civ.textColor = data.textColor;
     civ.secondaryColor = data.secondaryColor;
@@ -91,6 +96,7 @@ export class Civilization {
 
   getData(): CivilizationData {
     return {
+      id: this.id,
       templateID: this.templateID,
       color: this.color,
       textColor: this.textColor,

--- a/server/src/game/civilization.ts
+++ b/server/src/game/civilization.ts
@@ -19,7 +19,7 @@ export const civTemplates = [
 ];
 
 export interface CivilizationData {
-  id: number;
+  templateID: number;
   color: string;
   textColor: string;
   secondaryColor: string;
@@ -28,7 +28,7 @@ export interface CivilizationData {
 }
 
 export class Civilization {
-  private id: number;
+  private templateID: number;
   private color: string;
   private textColor: string;
   private secondaryColor: string;
@@ -38,9 +38,9 @@ export class Civilization {
   public units: Unit[];
   public startingKnowledge: KnowledgeMap;
 
-  constructor(id: number) {
-    const { color, textColor, name, startingKnowledge } = civTemplates[id];
-    this.id = id;
+  constructor(templateID: number) {
+    const { color, textColor, name, startingKnowledge } = civTemplates[templateID];
+    this.templateID = templateID;
     this.color = color;
     this.textColor = textColor;
     this.secondaryColor = color;
@@ -56,7 +56,7 @@ export class Civilization {
 
   export() {
     return {
-      id: this.id,
+      templateID: this.templateID,
       color: this.color,
       textColor: this.textColor,
       secondaryColor: this.secondaryColor,
@@ -67,7 +67,7 @@ export class Civilization {
   }
 
   static import(data: any): Civilization {
-    const civ = new Civilization(data.id);
+    const civ = new Civilization(data.templateID);
     civ.color = data.color;
     civ.textColor = data.textColor;
     civ.secondaryColor = data.secondaryColor;
@@ -91,7 +91,7 @@ export class Civilization {
 
   getData(): CivilizationData {
     return {
-      id: this.id,
+      templateID: this.templateID,
       color: this.color,
       textColor: this.textColor,
       secondaryColor: this.secondaryColor,

--- a/server/src/game/civilization.ts
+++ b/server/src/game/civilization.ts
@@ -26,7 +26,7 @@ export interface CivilizationData {
   textColor: string;
   secondaryColor: string;
   name: string;
-  leader: Leader | null;
+  leaderID: number | null;
 }
 
 export class Civilization extends Domain {
@@ -81,7 +81,7 @@ export class Civilization extends Domain {
       textColor: this.textColor,
       secondaryColor: this.secondaryColor,
       name: this.name,
-      leader: this.leader,
+      leaderID: this.leader?.id ?? null,
     };
   }
 }

--- a/server/src/game/index.ts
+++ b/server/src/game/index.ts
@@ -195,6 +195,8 @@ export class Game {
         throw new BugFixError('This should never be thrown. This means the world was not generated, and none of our previous checks caught it.');
       }
 
+      this.sendUpdates();
+
       this.sendToAll({
         update: [
           ['beginGame', [ [this.world.map.width, this.world.map.height], this.playerCount ]],

--- a/server/src/game/index.ts
+++ b/server/src/game/index.ts
@@ -58,7 +58,7 @@ export class Game {
 
     this.leaders = {};
     for (let leaderID = 0; leaderID < playerCount; leaderID++) {
-      this.leaders[leaderID] = new Leader();
+      this.leaders[leaderID] = new Leader(leaderID);
     }
 
     this.civPool = {};
@@ -122,10 +122,10 @@ export class Game {
       exportedPlayers[playerName] = player.export();
     }
 
-    const exportedLeaders: { [id: number]: any } = {};
+    const exportedLeaders: any[] = [];
     for (const leaderID in this.leaders) {
       const leader = this.leaders[leaderID];
-      exportedLeaders[leaderID] = leader.export();
+      exportedLeaders.push(leader.export());
     }
 
     return {
@@ -141,9 +141,8 @@ export class Game {
   static import(data: any): Game {
     const world = data.world === null ? null : World.import(data.world);
     const leaders: { [id: number]: Leader } = {};
-    for (const leaderID in data.leaders) {
-      const leaderData = data.leaders[leaderID];
-      leaders[Number(leaderID)] = Leader.import(leaderData);
+    for (const leaderData of data.leaders) {
+      leaders[Number(leaderData.id)] = Leader.import(leaderData);
     }
     const civPool = data.civPool;
     const players: { [name: string]: Player } = {};

--- a/server/src/game/index.ts
+++ b/server/src/game/index.ts
@@ -139,11 +139,11 @@ export class Game {
   }
 
   static import(data: any): Game {
-    const world = data.world === null ? null : World.import(data.world);
     const leaders: { [id: number]: Leader } = {};
     for (const leaderData of data.leaders) {
       leaders[Number(leaderData.id)] = Leader.import(leaderData);
     }
+    const world = data.world === null ? null : World.import(data.world, leaders);
     const civPool = data.civPool;
     const players: { [name: string]: Player } = {};
     for (const playerName in data.players) {
@@ -273,7 +273,7 @@ export class Game {
     const updates = this.world.getUpdates();
     this.forEachLeaderID((leaderID) => {
       this.sendToLeader(leaderID, {
-        update: updates.map(updateFn => updateFn(this.leaders[leaderID].getDomainIDs())),//.filter(update => update),
+        update: updates.map(updateFn => updateFn(this.leaders[leaderID])),//.filter(update => update),
       });
     });
   }

--- a/server/src/game/index.ts
+++ b/server/src/game/index.ts
@@ -193,8 +193,7 @@ export class Game {
       this.generateWorld();
 
       if (!this.hasStarted()) {
-        // Something went wrong. TODO - maybe retry here?
-        return;
+        throw new BugFixError('This should never be thrown. This means the world was not generated, and none of our previous checks caught it.');
       }
 
       this.sendToAll({
@@ -208,7 +207,8 @@ export class Game {
       this.forEachLeaderID((leaderID: number) => {
         this.sendToLeader(leaderID, {
           update: [
-            ['setMap', [this.world.map.getLeaderMap(this.getLeader(leaderID))]],
+            // Type assertion here to make the compiler happy - we've already guaranteed that world exsits.
+            ['setMap', [(this.world as World).map.getLeaderMap(this.getLeader(leaderID))]],
           ],
         });
         this.beginTurnForLeader(leaderID);
@@ -362,8 +362,7 @@ export class Game {
         this.civPool[civTemplateID] = player.leaderID;
         this.sendToAll({
           update: [
-            // TODO - rename to civPool
-            ['leaderPool', [ this.civPool, civTemplates, this.getPlayersData() ]],
+            ['civPool', [ this.civPool, civTemplates, this.getPlayersData() ]],
           ],
         });
       } else {

--- a/server/src/game/index.ts
+++ b/server/src/game/index.ts
@@ -107,6 +107,11 @@ export class Game {
             console.error('Map generation failed.');
             throw new GenerationFailed(`Could not generate map! (gave up after ${tries} tries)`);
           }
+          // Reset leader domains, as these would be set by the previous attempt
+          this.forEachLeaderID((leaderID) => {
+            const leader = this.getLeader(leaderID);
+            leader.clearDomains();
+          });
         } else throw err;
       }
     }

--- a/server/src/game/leader.ts
+++ b/server/src/game/leader.ts
@@ -1,85 +1,76 @@
-import { KnowledgeMap } from './map/tile/knowledge';
-
-const DEFAULT_START_KNOWLEDGE = {
-  'start': 100,
-  'food_0': 100,
-  'military_0': 100,
-  'science_1': 100,
-}
-
-export const leaderTemplates = [
-  { color: '#820000', textColor: '#ccc', name: 'Rokun', startingKnowledge: { 'science_1': 0, 'military_1': 100 } }, // RICH RED
-  { color: '#0a2ead', textColor: '#ccc', name: 'Azura' }, // BLUE
-  { color: '#03a300', textColor: '#222', name: 'Vertos' }, // GREEN
-  { color: '#bd9a02', textColor: '#222', name: 'Solei' }, // SAND YELLOW
-  { color: '#560e8a', textColor: '#ccc', name: 'Imperius' }, // ROYAL PURPLE
-  { color: '#bd7400', textColor: '#333', name: 'Baranog' }, // ORANGE
-];
+import { Civilization, CivilizationData } from './civilization';
+import { City, CityData } from './map/tile/city';
+import { Unit } from './map/tile/unit';
+import { Coords } from './world';
 
 export interface LeaderData {
-  id: number;
-  color: string;
-  textColor: string;
-  secondaryColor: string;
-  name: string;
-  civID: number | null;
+  domains: (CivilizationData | CityData)[];
 }
 
 export class Leader {
-  private id: number;
-  private color: string;
-  private textColor: string;
-  private secondaryColor: string;
-  private name: string;
-  private civID: number | null;
+  units: Unit[];
+  domains: (Civilization | City)[];
+  turnActive: boolean;
+  turnFinished: boolean;
 
-  public startingKnowledge: KnowledgeMap;
+  constructor() {
+    this.units = [];
+    this.domains = [];
+    this.turnActive = false;
+    this.turnFinished = false;
+  }
 
-  constructor(id: number) {
-    const { color, textColor, name, startingKnowledge } = leaderTemplates[id];
-    this.id = id;
-    this.color = color;
-    this.textColor = textColor;
-    this.secondaryColor = color;
-    this.name = name;
-    this.civID = null;
-
-    this.startingKnowledge = {
-      ...DEFAULT_START_KNOWLEDGE,
-      ...startingKnowledge,
+  export() {
+    return {
+      units: this.units.map(unit => unit.export()),
+      turnActive: this.turnActive,
+      turnFinished: this.turnFinished,
     };
   }
 
   static import(data: any): Leader {
-    const leader = new Leader(data.id);
-    leader.color = data.color;
-    leader.textColor = data.textColor;
-    leader.secondaryColor = data.secondaryColor;
-    leader.name = data.name;
-    leader.civID = null;
+    const leader =  new Leader();
+    leader.units = data.units.map((unitData: any) => Unit.import(unitData));
+    leader.turnActive = data.turnActive;
+    leader.turnFinished = data.turnFinished;
     return leader;
-  }
-
-  select(civID: number): void {
-    this.civID = civID;
-  }
-
-  unselect(): void {
-    this.civID = null;
-  }
-
-  isTaken(): boolean {
-    return this.civID !== null;
   }
 
   getData(): LeaderData {
     return {
-      id: this.id,
-      color: this.color,
-      textColor: this.textColor,
-      secondaryColor: this.secondaryColor,
-      name: this.name,
-      civID: this.civID,
-    };
+      domains: this.domains.map(domain => domain.getData()),
+    }
+  }
+
+  newTurn() {
+    this.turnActive = true;
+    this.turnFinished = false;
+
+    for (const unit of this.units) {
+      unit.newTurn();
+    }
+  }
+
+  endTurn() {
+    this.turnActive = false;
+  }
+
+  getUnits(): Unit[] {
+    return this.units;
+  }
+
+  getUnitPositions(): Coords[] {
+    return this.units.map(unit => unit.coords);
+  }
+
+  addUnit(unit: Unit): void {
+    this.units.push(unit);
+  }
+
+  removeUnit(unit: Unit): void {
+    const unitIndex = this.units.indexOf(unit);
+    if (unitIndex > -1) {
+      this.units.splice(unitIndex, 1);
+    }
   }
 }

--- a/server/src/game/leader.ts
+++ b/server/src/game/leader.ts
@@ -1,14 +1,96 @@
+import { InternalServerError } from '../utils/error';
 import { Civilization, CivilizationData } from './civilization';
+import { Tile } from './map/tile';
 import { City, CityData } from './map/tile/city';
 import { Unit } from './map/tile/unit';
 import { Coords } from './world';
+
+export enum DomainType {
+  CIVILIZATION,
+  CITY,
+}
+
+export type DomainID = {
+  subID: number,
+  type: DomainType,
+};
+
+type SpecificTypeDomainID<T extends DomainType> = DomainID & {
+  type: T;
+};
+export type CivDomainID = SpecificTypeDomainID<DomainType.CIVILIZATION>;
+export type CityDomainID = SpecificTypeDomainID<DomainType.CITY>;
+
+export const compareDomainIDs = (a: DomainID, b: DomainID): boolean => a.type === b.type && a.subID === b.subID;
+export const isCivDomain = (domainID: DomainID): domainID is CivDomainID => domainID.type === DomainType.CIVILIZATION;
+export const isCityDomain = (domainID: DomainID): domainID is CityDomainID => domainID.type === DomainType.CITY;
+
+export class Domain {
+  public id: number;
+  public type: DomainType;
+  public units: Unit[];
+  protected leader: Leader | null;
+
+  constructor(id: number, type: DomainType) {
+    this.id = id;
+    this.type = type;
+    this.units = [];
+    this.leader = null;
+  }
+  
+  public getData(): any {
+    throw new InternalServerError('Attempted illegal call to Domain.getData.');
+  }
+
+  public getDomainID(): DomainID {
+    return {
+      subID: this.id,
+      type: this.type,
+    };
+  }
+
+  public setLeader(leader: Leader): void {
+    this.leader = leader;
+  }
+
+  public clearLeader(): void {
+    this.leader = null;
+  }
+
+  public hasLeader(): boolean {
+    return this.leader !== null;
+  }
+
+  public getUnits(): Unit[] {
+    return this.units;
+  }
+
+  public getUnitPositions(): Coords[] {
+    return this.units.map(unit => unit.coords);
+  }
+
+  public addUnit(unit: Unit): void {
+    this.units.push(unit);
+  }
+
+  public removeUnit(unit: Unit): void {
+    const unitIndex = this.units.indexOf(unit);
+    if (unitIndex > -1) {
+      this.units.splice(unitIndex, 1);
+    }
+  }
+
+  public ownsUnit(unit: Unit): boolean {
+    return compareDomainIDs(unit.domainID, this.getDomainID());
+  }
+}
 
 export interface LeaderData {
   domains: (CivilizationData | CityData)[];
 }
 
 export class Leader {
-  domains: (Civilization | City)[];
+  private domains: Domain[];
   turnActive: boolean;
   turnFinished: boolean;
 
@@ -38,8 +120,31 @@ export class Leader {
     }
   }
 
-  getDomainIDs(): string[] {
-    return this.domains.map(domain => domain instanceof Civilization ? `civ_${domain.id}` : `city_${domain.id}`);
+  public addDomain(domain: Domain) {
+    this.domains.push(domain);
+  }
+
+  public removeDomain(domain: Domain) {
+    const domainIndex = this.domains.indexOf(domain);
+    if (domainIndex > -1) {
+      this.domains.splice(domainIndex, 1);
+    }
+  }
+
+  public getDomainIDs(): DomainID[] {
+    return this.domains.map(domain => domain.getDomainID());
+  }
+
+  public forEachCivDomainID(callback: (domainID: CivDomainID) => any): void {
+    this.getDomainIDs().forEach((domainID => {
+      if (isCivDomain(domainID)) callback(domainID);
+    }));
+  }
+
+  public forEachCityDomainID(callback: (domainID: CityDomainID) => any): void {
+    this.getDomainIDs().forEach((domainID => {
+      if (isCityDomain(domainID)) callback(domainID);
+    }));
   }
 
   newTurn() {
@@ -69,5 +174,15 @@ export class Leader {
 
   getUnitPositions(): Coords[] {
     return this.getUnits().map(unit => unit.coords);
+  }
+
+  controlsUnit(unit: Unit): boolean {
+    return this.domains.some(domain => domain.ownsUnit(unit));
+  }
+
+  controlsTile(tile: Tile): boolean {
+    const owner = tile.owner;
+    if (!owner) return false;
+    return this.domains.some(domain => (owner.getDomainID() === domain.getDomainID()));
   }
 }

--- a/server/src/game/leader.ts
+++ b/server/src/game/leader.ts
@@ -38,6 +38,10 @@ export class Leader {
     }
   }
 
+  getDomainIDs(): string[] {
+    return this.domains.map(domain => domain instanceof Civilization ? `civ_${domain.id}` : `city_${domain.id}`);
+  }
+
   newTurn() {
     this.turnActive = true;
     this.turnFinished = false;

--- a/server/src/game/leader.ts
+++ b/server/src/game/leader.ts
@@ -37,6 +37,19 @@ export class Domain {
     this.units = [];
     this.leader = null;
   }
+
+  protected baseExport() {
+    return {
+      id: this.id,
+      leader: this.leader?.id,
+      units: this.units.map(unit => unit.export()),
+    }
+  }
+
+  protected baseImport(data: any) {
+    // The leader is not set here, it must be set by call to World.setDomainLeader and is done during World import
+    this.units = data.units.map((unitData: any) => Unit.import(unitData));
+  }
   
   public getData(): any {
     throw new InternalServerError('Attempted illegal call to Domain.getData.');

--- a/server/src/game/leader.ts
+++ b/server/src/game/leader.ts
@@ -211,6 +211,10 @@ export class Leader {
   controlsTile(tile: Tile): boolean {
     const owner = tile.owner;
     if (!owner) return false;
-    return this.domains.some(domain => (owner.getDomainID() === domain.getDomainID()));
+    return this.domains.some(domain => (
+      compareDomainIDs(owner.getDomainID(), domain.getDomainID()) || (
+        owner.civID && compareDomainIDs(owner.civID, domain.getDomainID())
+      )
+    ));
   }
 }

--- a/server/src/game/leader.ts
+++ b/server/src/game/leader.ts
@@ -138,15 +138,24 @@ export class Leader {
     }
   }
 
-  public addDomain(domain: Domain) {
+  public addDomain(domain: Domain): void {
+    if (this.ownsDomain(domain)) return;
     this.domains.push(domain);
   }
 
-  public removeDomain(domain: Domain) {
+  public removeDomain(domain: Domain): void {
     const domainIndex = this.domains.indexOf(domain);
     if (domainIndex > -1) {
       this.domains.splice(domainIndex, 1);
     }
+  }
+
+  public clearDomains(): void {
+    this.domains = [];
+  }
+
+  public ownsDomain(domain: Domain): boolean {
+    return this.getDomainIDs().some((domainID => compareDomainIDs(domain.getDomainID(), domainID)));
   }
 
   public getDomainIDs(): DomainID[] {
@@ -191,6 +200,7 @@ export class Leader {
   }
 
   getUnitPositions(): Coords[] {
+    console.log(this.getUnits().map(unit => unit.coords))
     return this.getUnits().map(unit => unit.coords);
   }
 

--- a/server/src/game/leader.ts
+++ b/server/src/game/leader.ts
@@ -8,13 +8,11 @@ export interface LeaderData {
 }
 
 export class Leader {
-  units: Unit[];
   domains: (Civilization | City)[];
   turnActive: boolean;
   turnFinished: boolean;
 
   constructor() {
-    this.units = [];
     this.domains = [];
     this.turnActive = false;
     this.turnFinished = false;
@@ -22,7 +20,6 @@ export class Leader {
 
   export() {
     return {
-      units: this.units.map(unit => unit.export()),
       turnActive: this.turnActive,
       turnFinished: this.turnFinished,
     };
@@ -30,7 +27,6 @@ export class Leader {
 
   static import(data: any): Leader {
     const leader =  new Leader();
-    leader.units = data.units.map((unitData: any) => Unit.import(unitData));
     leader.turnActive = data.turnActive;
     leader.turnFinished = data.turnFinished;
     return leader;
@@ -46,8 +42,10 @@ export class Leader {
     this.turnActive = true;
     this.turnFinished = false;
 
-    for (const unit of this.units) {
-      unit.newTurn();
+    for (const domain of this.domains) {
+      for (const unit of domain.units) {
+        unit.newTurn();
+      }
     }
   }
 
@@ -56,21 +54,16 @@ export class Leader {
   }
 
   getUnits(): Unit[] {
-    return this.units;
+    const units: Unit[] = [];
+    for (const domain of this.domains) {
+      for (const unit of domain.units) {
+        units.push(unit);
+      }
+    }
+    return units;
   }
 
   getUnitPositions(): Coords[] {
-    return this.units.map(unit => unit.coords);
-  }
-
-  addUnit(unit: Unit): void {
-    this.units.push(unit);
-  }
-
-  removeUnit(unit: Unit): void {
-    const unitIndex = this.units.indexOf(unit);
-    if (unitIndex > -1) {
-      this.units.splice(unitIndex, 1);
-    }
+    return this.getUnits().map(unit => unit.coords);
   }
 }

--- a/server/src/game/leader.ts
+++ b/server/src/game/leader.ts
@@ -90,11 +90,13 @@ export interface LeaderData {
 }
 
 export class Leader {
+  public id: number;
   private domains: Domain[];
   turnActive: boolean;
   turnFinished: boolean;
 
-  constructor() {
+  constructor(id: number) {
+    this.id = id;
     this.domains = [];
     this.turnActive = false;
     this.turnFinished = false;
@@ -102,13 +104,14 @@ export class Leader {
 
   export() {
     return {
+      id: this.id,
       turnActive: this.turnActive,
       turnFinished: this.turnFinished,
     };
   }
 
   static import(data: any): Leader {
-    const leader =  new Leader();
+    const leader =  new Leader(data.id);
     leader.turnActive = data.turnActive;
     leader.turnFinished = data.turnFinished;
     return leader;

--- a/server/src/game/leader.ts
+++ b/server/src/game/leader.ts
@@ -99,6 +99,7 @@ export class Domain {
 }
 
 export interface LeaderData {
+  id: number;
   domains: (CivilizationData | CityData)[];
 }
 
@@ -132,6 +133,7 @@ export class Leader {
 
   getData(): LeaderData {
     return {
+      id: this.id,
       domains: this.domains.map(domain => domain.getData()),
     }
   }

--- a/server/src/game/map/index.ts
+++ b/server/src/game/map/index.ts
@@ -602,7 +602,7 @@ export class Map {
     if (!this.canSettleOn(tile)) return false;
 
     const civID = settler.domainID;
-    if (!isCivDomain(civID)) return false; // City-based settlers are not allowed.
+    if (!isCivDomain(civID)) return false; // City-based settlers are not allowed. This is a redundant check, and will usually not be relevant.
 
     const cityID = this.cities.length;
     const city: City = new City(cityID, coords, name, civID);

--- a/server/src/game/map/tile/city.ts
+++ b/server/src/game/map/tile/city.ts
@@ -73,8 +73,7 @@ export class City extends Domain {
    * @returns the "controlling" domainID: if this a city state, return the city's own ID. Else, return the parent Civ's ID.
    */
   getControllingDomainID(): DomainID {
-    if (!this.civID) return this.getDomainID();
-    else return this.civID;
+    return this.civID ?? this.getDomainID();
   }
 
   addTile(coords: Coords) {

--- a/server/src/game/map/tile/city.ts
+++ b/server/src/game/map/tile/city.ts
@@ -66,6 +66,15 @@ export class City extends Domain {
     return this.tiles;
   }
 
+  /**
+   * 
+   * @returns the "controlling" domainID: if this a city state, return the city's own ID. Else, return the parent Civ's ID.
+   */
+  getControllingDomainID(): DomainID {
+    if (!this.civID) return this.getDomainID();
+    else return this.civID;
+  }
+
   addTile(coords: Coords) {
     this.tiles.add(coords);
   }

--- a/server/src/game/map/tile/city.ts
+++ b/server/src/game/map/tile/city.ts
@@ -36,6 +36,7 @@ export class City extends Domain {
       tiles.push(coords)
     }
     return {
+      ...super.baseExport(),
       center: this.center,
       name: this.name,
       civID: this.civID,
@@ -45,7 +46,7 @@ export class City extends Domain {
   }
 
   static import(data: any): City {
-    const city = new (data.isBarbarian ? BarbarianCamp : City)(data.center, data.name, data.civID);
+    const city = new (data.isBarbarian ? BarbarianCamp : City)(data.id, data.center, data.name, data.civID);
     city.tiles = new Set();
     for (const coords of data.tiles) {
       city.addTile(coords);

--- a/server/src/game/map/tile/city.ts
+++ b/server/src/game/map/tile/city.ts
@@ -8,6 +8,7 @@ import { Improvement } from "./improvement";
 import { Unit } from "./unit";
 
 export interface CityData {
+  id: number;
   name: string;
   civID?: CivDomainID;
   isBarbarian: boolean;
@@ -56,6 +57,7 @@ export class City extends Domain {
 
   getData(): CityData {
     return {
+      id: this.id,
       name: this.name,
       civID: this.civID,
       isBarbarian: this instanceof BarbarianCamp,

--- a/server/src/game/map/tile/errand.ts
+++ b/server/src/game/map/tile/errand.ts
@@ -45,7 +45,7 @@ export class WorkErrand {
     },
     [ErrandType.UNIT_TRAINING]: (world, map, tile, action) => {
       if (!(tile.owner && action.location)) return;
-      const newUnit = new Unit(action.option, action.location, tile.owner.civID, tile.owner.civID ? undefined : tile.owner.id);
+      const newUnit = new Unit(action.option, action.location, tile.owner.getControllingDomainID());
       if (tile.unit) {
         // if there is already a unit on this tile, we must figure something else out
       } else {

--- a/server/src/game/map/tile/index.ts
+++ b/server/src/game/map/tile/index.ts
@@ -155,7 +155,7 @@ export class Tile {
 
   isDiscoveredBy(domainID: DomainID): boolean {
     const key = Tile.getDomainVisibilityKey(domainID);
-    return this.discoveredBy[key];
+    return key in this.discoveredBy;
   }
 
   isVisibleTo(domainID: DomainID): boolean {
@@ -163,14 +163,18 @@ export class Tile {
     return this.visibleTo[key] > 0;
   }
 
+
   setVisibility(domainID: DomainID, visible: boolean): void {
     const key = Tile.getDomainVisibilityKey(domainID);
+
+    if (!(key in this.visibleTo)) this.visibleTo[key] = 0;
+
     if (visible) {
       this.visibleTo[key]++;
     } else {
       this.visibleTo[key]--;
     }
-    key
+
     if (visible && !this.discoveredBy[key]) {
       this.discoveredBy[key] = true;
     }

--- a/server/src/game/map/tile/index.ts
+++ b/server/src/game/map/tile/index.ts
@@ -62,8 +62,8 @@ export class Tile {
     Wall | null,
   ];
 
-  discoveredBy: { [civID: number]: boolean };
-  visibleTo: { [civID: number]: number };
+  discoveredBy: { [domainID: string]: boolean };
+  visibleTo: { [domainID: string]: number };
 
   public baseYield: Yield;
 
@@ -126,10 +126,10 @@ export class Tile {
     };
   }
 
-  getVisibleData(civID: number): TileData {
+  getVisibleData(domainID: string): TileData {
     return {
       ...this.getDiscoveredData(),
-      unit: this.unit?.getData(civID),
+      unit: this.unit?.getData(domainID),
       visible: true,
     }
   }
@@ -148,20 +148,29 @@ export class Tile {
     this.unit = unit;
   }
 
-  setVisibility(civID: number, visible: boolean): void {
+  /**
+   * 
+   * @param domainID can be both a civID or a cityID. To differentiate these, this value must be prefixed with either `civ_` or `city_`.
+   * @param visible 
+   */
+  setVisibility(domainID: string, visible: boolean): void {
     if (visible) {
-      this.visibleTo[civID]++;
+      this.visibleTo[domainID]++;
     } else {
-      this.visibleTo[civID]--;
+      this.visibleTo[domainID]--;
     }
 
-    if (visible && !this.discoveredBy[civID]) {
-      this.discoveredBy[civID] = true;
+    if (visible && !this.discoveredBy[domainID]) {
+      this.discoveredBy[domainID] = true;
     }
   }
 
-  clearVisibility(civID: number): void {
-    this.visibleTo[civID] = 0;
+  /**
+   * 
+   * @param domainID can be both a civID or a cityID. To differentiate these, this value must be prefixed with either `civ_` or `city_`.
+   */
+  clearVisibility(domainID: string): void {
+    this.visibleTo[domainID] = 0;
   }
 
   getWall(direction: number): Wall | null {

--- a/server/src/game/map/tile/unit.ts
+++ b/server/src/game/map/tile/unit.ts
@@ -1,4 +1,5 @@
 import { getAdjacentCoords } from '../../../utils';
+import { DomainID, compareDomainIDs } from '../../leader';
 import { Coords } from '../../world';
 import { KnowledgeBucket, KnowledgeMap } from './knowledge';
 import { Yield } from './yield';
@@ -12,7 +13,7 @@ export interface UnitData {
   type: string,
   hp: number,
   movement: number,
-  domainID: string,
+  domainID: DomainID,
   promotionClass: PromotionClass,
   attackRange?: number,
   knowledge: KnowledgeMap,
@@ -131,7 +132,7 @@ export class Unit {
   combatStats: [number, number, number];
   attackRange?: number;
   visionRange: number;
-  domainID: string;
+  domainID: DomainID;
   coords: Coords;
   alive: boolean;
   cloaked?: boolean;
@@ -146,7 +147,7 @@ export class Unit {
     ));
   }
 
-  constructor(type: string, coords: Coords, domainID: string, knowledge?: KnowledgeMap) {
+  constructor(type: string, coords: Coords, domainID: DomainID, knowledge?: KnowledgeMap) {
     this.type = type;
     this.hp = 100;
     this.movement = 0;
@@ -198,8 +199,8 @@ export class Unit {
     return unit;
   }
 
-  getData(domainID: string): UnitData | undefined {
-    return !this.cloaked || domainID === this.domainID ? {
+  getData(domainID: DomainID): UnitData | undefined {
+    return !this.cloaked || compareDomainIDs(domainID, this.domainID) ? {
       type: this.type,
       hp: this.hp,
       movement: this.movement,

--- a/server/src/game/map/tile/unit.ts
+++ b/server/src/game/map/tile/unit.ts
@@ -12,7 +12,7 @@ export interface UnitData {
   type: string,
   hp: number,
   movement: number,
-  civID?: number,
+  domainID: string,
   promotionClass: PromotionClass,
   attackRange?: number,
   knowledge: KnowledgeMap,
@@ -131,8 +131,7 @@ export class Unit {
   combatStats: [number, number, number];
   attackRange?: number;
   visionRange: number;
-  civID?: number;
-  cityID?: number;
+  domainID: string;
   coords: Coords;
   alive: boolean;
   cloaked?: boolean;
@@ -147,7 +146,7 @@ export class Unit {
     ));
   }
 
-  constructor(type: string, coords: Coords, civID?: number, cityID?: number, knowledge?: KnowledgeMap) {
+  constructor(type: string, coords: Coords, domainID: string, knowledge?: KnowledgeMap) {
     this.type = type;
     this.hp = 100;
     this.movement = 0;
@@ -158,8 +157,7 @@ export class Unit {
       this.attackRange = Unit.attackRangeTable[type];
     }
     this.visionRange = Unit.visionRangeTable[type] ?? Unit.visionRangeTable.default;
-    this.civID = civID;
-    this.cityID = cityID;
+    this.domainID = domainID;
     this.coords = coords;
     this.alive = true;
     this.knowledge = knowledge ?? {};
@@ -174,8 +172,7 @@ export class Unit {
       type: this.type,
       hp: this.hp,
       movement: this.movement,
-      civID: this.civID,
-      cityID: this.cityID,
+      domainID: this.domainID,
       coords: this.coords,
       alive: this.alive,
       knowledge: this.knowledge,
@@ -184,7 +181,7 @@ export class Unit {
   }
 
   static import(data: any): Unit {
-    const unit = new Unit(data.type, data.coords, data.civID, data.cityID, data.knowledge);
+    const unit = new Unit(data.type, data.coords, data.domainID, data.knowledge);
     unit.hp = data.hp;
     unit.movement = data.movement;
     unit.promotionClass = Unit.promotionClassTable[unit.type];
@@ -201,12 +198,12 @@ export class Unit {
     return unit;
   }
 
-  getData(civID: number): UnitData | undefined {
-    return !this.cloaked || civID === this.civID ? {
+  getData(domainID: string): UnitData | undefined {
+    return !this.cloaked || domainID === this.domainID ? {
       type: this.type,
       hp: this.hp,
       movement: this.movement,
-      civID: this.civID,
+      domainID: this.domainID,
       promotionClass: this.promotionClass,
       attackRange: this.attackRange,
       knowledge: this.knowledge,

--- a/server/src/game/map/trade.ts
+++ b/server/src/game/map/trade.ts
@@ -1,3 +1,4 @@
+import { DomainID } from "../leader";
 import { Coords } from "../world";
 import { Map } from "./index";
 import { Improvement, ImprovementData } from "./tile/improvement";
@@ -16,7 +17,7 @@ export type TraderData = {
 };
 
 export class Trader {
-  civID: number;
+  domainID: DomainID;
   path: Coords[];
   source: Improvement;
   sink: Improvement;
@@ -30,7 +31,7 @@ export class Trader {
   private storage: ResourceStore;
 
   constructor(
-    civID: number,
+    domainID: DomainID,
     [path, length]: Route,
     source: Improvement,
     sink: Improvement,
@@ -38,7 +39,7 @@ export class Trader {
     capacity: YieldParams,
     mode: MovementClass
   ) {
-    this.civID = civID;
+    this.domainID = domainID;
     this.path = path;
     this.source = source;
     this.sink = sink;
@@ -58,7 +59,7 @@ export class Trader {
 
   export() {
     return {
-      civID: this.civID,
+      domainID: this.domainID,
       path: this.path,
       speed: this.speed,
       length: this.length,
@@ -72,14 +73,14 @@ export class Trader {
   /***
    * import() needs a reference to the Map in order to get references to the source and sink Improvements
    */
-  static import(map: Map, {civID, path, speed, length, expired, turnsElapsed, storage, movementClass}: any): Trader {
+  static import(map: Map, {domainID, path, speed, length, expired, turnsElapsed, storage, movementClass}: any): Trader {
     // This is safe, since a Route is guaranteed to always start at the source and end at the sink.
     const source = map.getTileOrThrow(path[0]);
     const sink = map.getTileOrThrow(path[path.length - 1]);
     if (source.improvement && sink.improvement) {
       const capacity = storage.capacity;
       delete storage.capacity;
-      const trader = new Trader(civID, [path, length], source.improvement, sink.improvement, speed, capacity, movementClass);
+      const trader = new Trader(domainID, [path, length], source.improvement, sink.improvement, speed, capacity, movementClass);
       trader.storage.incr(new Yield(storage));
       trader.expired = expired;
       trader.turnsElapsed = turnsElapsed;

--- a/server/src/game/player.ts
+++ b/server/src/game/player.ts
@@ -1,24 +1,27 @@
 import * as WebSocket from 'ws';
-import { PlayerData } from '../utils';
 import WebSocketManager from './connection';
 
+export interface PlayerData {
+  leaderID: number;
+}
+
 export class Player {
-  civID: number;
+  leaderID: number;
   ready: boolean;
   private connection: WebSocketManager | null;
 
-  constructor(civID: number, connection: WebSocketManager | null) {
-    this.civID = civID;
+  constructor(leaderID: number, connection: WebSocketManager | null) {
+    this.leaderID = leaderID;
     this.ready = false;
     this.connection = connection;
   }
 
   export() {
-    return { civID: this.civID };
+    return { leaderID: this.leaderID };
   }
 
   static import(data: any): Player {
-    return new Player(data.civID, null)
+    return new Player(data.leaderID, null)
   }
 
   isAI(): boolean {
@@ -26,7 +29,7 @@ export class Player {
   }
 
   getData(): PlayerData {
-    return { civID: this.civID };
+    return { leaderID: this.leaderID };
   }
   
   reset(connection: WebSocketManager | null): void {

--- a/server/src/game/world.ts
+++ b/server/src/game/world.ts
@@ -163,6 +163,9 @@ export class World {
 
     domain.setLeader(leader);
     leader.addDomain(domain);
+
+    this.updates.push((leader) => ['leaderUpdate', [leader.id, leader.getData()]]);
+
     return true;
   }
 

--- a/server/src/game/world.ts
+++ b/server/src/game/world.ts
@@ -243,16 +243,14 @@ export class World {
   // map, civs
   addUnit(unit: Unit): void {
     if (this.map.isInBounds(unit.coords)) {
-      if (isCivDomain(unit.domainID)) this.getCiv(unit.domainID).addUnit(unit);
-      else if (isCityDomain(unit.domainID)) this.getCity(unit.domainID).addUnit(unit);
+      this.getDomain(unit.domainID).addUnit(unit);
       this.map.getTileOrThrow(unit.coords).setUnit(unit);
     }
   }
 
   // map, civs
   removeUnit(unit: Unit): void {
-    if (isCivDomain(unit.domainID)) this.getCiv(unit.domainID).removeUnit(unit);
-    else if (isCityDomain(unit.domainID)) this.getCity(unit.domainID).removeUnit(unit);
+    this.getDomain(unit.domainID).removeUnit(unit);
     this.updates.push(() => ['unitKilled', [ unit.coords, unit ]]);
     this.map.getTileOrThrow(unit.coords).setUnit(undefined);
     // TODO: make this more intelligent

--- a/server/src/game/world.ts
+++ b/server/src/game/world.ts
@@ -1,10 +1,11 @@
 import { Map } from './map';
 import { Unit } from './map/tile/unit';
-import { Civilization, CivilizationData } from './civilization';
+import { Leader, CivDomainID, isCityDomain, isCivDomain, CityDomainID, DomainID, Domain } from './leader';
 import { Event } from '../utils';
 import { Random } from '../utils/random';
-import { Leader, LeaderData, leaderTemplates } from './leader';
-import { NoStartLocation } from '../utils/error';
+import { Civilization, CivilizationData } from './civilization';
+import { NoStartLocation, ValueError } from '../utils/error';
+import { City } from './map/tile/city';
 
 export interface Coords {
   x: number;
@@ -13,72 +14,68 @@ export interface Coords {
 
 const DAMAGE_MULTIPLIER = 20;
 
-type WorldImportArgs = [Map, { [civID: number]: Civilization }, number, { [leaderID: number]: Leader }, number];
+type WorldImportArgs = [Map, { [civID: number]: Civilization }, number, number];
 
 export class World {
   map: Map;
   civs: { [civID: number]: Civilization };
   civsCount: number;
-  leaderPool: { [leaderID: number]: Leader };
-  updates: { (civID: number): Event }[];
+  updates: { (leader: Leader): Event }[];
   random: Random;
 
   public currentTurn: number;
 
-  constructor(args: [map: Map, civsCount: number] | WorldImportArgs) {
+  constructor(args: [map: Map, civsCount: number, civTemplateLeaders: [number, Leader][]] | WorldImportArgs) {
     this.updates = [];
 
-    if (args.length === 5) {
-      const [map, civs, civsCount, leaderPool, currentTurn] = args;
+    if (args.length === 4) {
+      const [map, civs, civsCount, currentTurn] = args;
       this.map = map;
       this.civs = civs;
       this.civsCount = civsCount;
-      this.leaderPool = leaderPool;
       this.random = new Random(map.seed);
       this.currentTurn = currentTurn;
       return;
     }
 
-    const [ map, civsCount ] = args;
+    const [ map, civsCount, civTemplateLeaders ] = args;
 
     this.random = new Random(map.seed);
     this.map = map;
 
     this.civsCount = civsCount;
     this.civs = {};
-    this.leaderPool = {};
 
     for (let civID = 0; civID < this.civsCount; civID++) {
-      this.civs[civID] = new Civilization();
+      const [templateID, leader] = civTemplateLeaders[civID];
+      this.civs[civID] = new Civilization(civID, templateID);
+      const domainID = this.civs[civID].getDomainID();
 
-      this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
-        this.addUnit(new Unit('settler', settlerCoords, civID));
-        this.addUnit(new Unit('builder', builderCoords, civID));
-        this.addUnit(new Unit('scout', scoutCoords, civID));
+      this.getStartLocation(([settlerCoords, builderCoords, scoutCoords]) => {
+        this.addUnit(new Unit('settler', settlerCoords, domainID, this.civs[civID].startingKnowledge));
+        this.addUnit(new Unit('builder', builderCoords, domainID, this.civs[civID].startingKnowledge));
+        this.addUnit(new Unit('scout', scoutCoords, domainID, this.civs[civID].startingKnowledge));
       });
 
-      this.updateCivTileVisibility(civID);
+      this.setDomainLeader(domainID, leader)
+
+      this.updateLeaderTileVisibility(leader);
     }
 
     const barbarianTribes = Math.ceil(map.height * map.width / 1500);
     for (let i = 0; i < barbarianTribes; i++) {
-      this.getStartLocaltion(([settlerCoords, _, scoutCoords]) => {
-        const cityID = this.map.newBarbarianCampAt(settlerCoords);
-        if (cityID !== null) this.addUnit(new Unit('scout', scoutCoords, undefined, cityID));
+      this.getStartLocation(([settlerCoords, _, scoutCoords]) => {
+        const domainID = this.map.newBarbarianCampAt(settlerCoords);
+        if (domainID !== null) this.addUnit(new Unit('scout', scoutCoords, domainID));
       });
-    }
-
-    for (let i = 0; i < leaderTemplates.length; i++) {
-      this.leaderPool[i] = new Leader(i);
     }
 
     this.currentTurn = 1;
 
-
     // this.colorPool = colorList.reduce((obj: { [color: string]: boolean }, color: string) => ({...obj, [color]: true}), {});
   }
 
-  private getStartLocaltion(callback: (coords: [Coords, Coords, Coords]) => void): void {
+  private getStartLocation(callback: (coords: [Coords, Coords, Coords]) => void): void {
     for (let i = 0; i < 1000; i++) {
       const x = this.random.randInt(0, this.map.width-1);
       const y = this.random.randInt(0, this.map.height-1);
@@ -116,22 +113,16 @@ export class World {
       map: this.map.export(),
       civs: exportedCivs,
       civsCount: this.civsCount,
-      leaderPool: this.leaderPool,
       currentTurn: this.currentTurn,
     };
   }
 
-  static import(data: any): World {
+  static import(data: any, leaders: { [id: number]: Leader }): World {
     const [map, callbacks] = Map.import(data.map);
     const civs = {};
     const civsCount = data.civsCount;
-    const leaderPool: { [id: number]: Leader } = {};
-    for (const leaderID in data.leaderPool) {
-      const leaderData = data.leaderPool[leaderID];
-      leaderPool[Number(leaderID)] = Leader.import(leaderData);
-    }
 
-    const world = new World([map, civs, civsCount, leaderPool, data.currentTurn]);
+    const world = new World([map, civs, civsCount, data.currentTurn]);
 
     for (const civID in data.civs) {
       const civData = data.civs[civID];
@@ -140,69 +131,53 @@ export class World {
       for (const unit of units) {
         world.addUnit(unit);
       }
-      world.updateCivTileVisibility(Number(civID));
-    }
-
-    for (const leaderID in leaderPool) {
-      const leaderData = data.leaderPool[leaderID];
-      world.leaderPool[Number(leaderID)] = Leader.import(leaderData);
-      if (leaderData.civID !== null) {
-        world.setCivLeader(leaderData.civID, Number(leaderID));
+      if (civData.leader !== null) {
+        world.updateLeaderTileVisibility(leaders[civData.leader]);
+        world.setDomainLeader(civData.domainID, leaders[civData.leader]);
       }
     }
 
     for (const cb of callbacks) {
-      cb(world);
+      cb(world, leaders);
     }
 
     return world;
   }
 
-  getUpdates(): { (civID: number): Event }[] {
+  getUpdates(): { (leader: Leader): Event }[] {
     // TODO: more updates?
     return this.map.getUpdates().concat(this.updates.splice(0));
   }
 
-  // leaders
-  getLeaderPool(): [LeaderData[], LeaderData[]] {
-    const leaderList: LeaderData[] = [];
-    const takenLeaderList: LeaderData[] = [];
-
-    for (const id in this.leaderPool) {
-      const leader = this.leaderPool[id];
-      if (leader.isTaken()) {
-        takenLeaderList.push(leader.getData());
-      } else {
-        leaderList.push(leader.getData());
-      }
-    }
-
-    return [leaderList, takenLeaderList];
-  }
-
-  // leaders, civs
-  setCivLeader(civID: number, leaderID: number): boolean {
-    const leader = this.leaderPool[leaderID];
-    if (!leader || leader.isTaken()) {
+  /**
+   * Sets the leader of a domain if none already exists. *Cannot* transfer a domain from one leader to another.
+   * @param domainID 
+   * @param leader 
+   * @returns 
+   */
+  setDomainLeader(domainID: DomainID, leader: Leader): boolean {
+    const domain = this.getDomain(domainID);
+    if (!domain || domain.hasLeader()) {
       return false;
     }
 
-    if (this.civs[civID].leader) {
-      this.civs[civID].leader?.unselect();
-    }
-    this.civs[civID].leader = leader;
-    leader.select(civID);
-    for (const unit of this.civs[civID].getUnits()) {
-      unit.knowledge = {};
-      unit.updateKnowledge(leader.startingKnowledge);
-    }
-
+    domain.setLeader(leader);
+    leader.addDomain(domain);
     return true;
   }
 
-  // civs
-  getCiv(civID: number): Civilization {
-    return this.civs[civID];
+  getDomain(domainID: DomainID): Domain {
+    if (isCivDomain(domainID)) return this.getCiv(domainID);
+    else if (isCityDomain(domainID)) return this.getCity(domainID);
+    else throw new ValueError('Bad domain ID type: ' + domainID.type);
+  }
+
+  getCiv(civID: CivDomainID): Civilization {
+    return this.civs[civID.subID];
+  }
+
+  getCity(cityID: CityDomainID): City {
+    return this.map.cities[cityID.subID];
   }
 
   // civs
@@ -218,60 +193,68 @@ export class World {
   }
 
   // map, civs
-  updateCivTileVisibility(civID: number): void {
-    const cityTiles: Coords[] = [];
-    this.map.forEachTile((tile, coords) => {
-      tile.clearVisibility(civID);
-      if (tile.owner?.civID === civID) {
-        tile.setVisibility(civID, true);
-        cityTiles.push(coords)
-      }
+  updateLeaderTileVisibility(leader: Leader): void {
+    leader.forEachCityDomainID((domainID: CityDomainID) => {
+      this.updateCityTileVisibility(domainID);
     });
+
+    leader.forEachCivDomainID((domainID: CivDomainID) => {
+      this.updateCivTileVisibility(domainID);
+    });
+  }
+
+  updateCityTileVisibility(domainID: CityDomainID): void {
+    const city = this.getCity(domainID);
+    const cityTiles: Coords[] = [];
+    for (const coords of city.getTiles()) {
+      this.map.getTileOrThrow(coords).setVisibility(domainID, true);
+      cityTiles.push(coords);
+    }
     for (const coords of cityTiles) {
       for (const neighbor of this.map.getNeighborsCoords(coords, 1, { filter: (tile) => {
-        return tile.owner?.civID !== civID;
+        return tile.owner?.id !== city.id;
       } })) {
         const tile = this.map.getTileOrThrow(neighbor);
-        tile.setVisibility(civID, true);
+        tile.setVisibility(domainID, true);
       }
     }
-    const civ = this.civs[civID];
+
+    for (const unit of city.units) {
+      for (const coords of this.map.getVisibleTilesCoords(unit)) {
+        const tile = this.map.getTileOrThrow(coords);
+        tile.setVisibility(domainID, true);
+      }
+    }
+  }
+
+  updateCivTileVisibility(domainID: CivDomainID): void {
+    const civ = this.getCiv(domainID);
     for (const unit of civ.units) {
       for (const coords of this.map.getVisibleTilesCoords(unit)) {
         const tile = this.map.getTileOrThrow(coords);
-        tile.setVisibility(civID, true);
+        tile.setVisibility(domainID, true);
       }
     }
-  }
-
-  // civs
-  getCivUnits(civID: number): Unit[] {
-    return this.civs[civID].getUnits();
-  }
-
-  // civs
-  getCivUnitPositions(civID: number): Coords[] {
-    return this.civs[civID].getUnitPositions();
   }
 
   // map, civs
   addUnit(unit: Unit): void {
     if (this.map.isInBounds(unit.coords)) {
-      if (unit.civID !== undefined) this.civs[unit.civID].addUnit(unit);
-      else if (unit.cityID !== undefined) this.map.cities[unit.cityID].addUnit(unit);
+      if (isCivDomain(unit.domainID)) this.getCiv(unit.domainID).addUnit(unit);
+      else if (isCityDomain(unit.domainID)) this.getCity(unit.domainID).addUnit(unit);
       this.map.getTileOrThrow(unit.coords).setUnit(unit);
     }
   }
 
   // map, civs
   removeUnit(unit: Unit): void {
-    if (unit.civID !== undefined) this.civs[unit.civID].removeUnit(unit);
-    else if (unit.cityID !== undefined) this.map.cities[unit.cityID].removeUnit(unit);
+    if (isCivDomain(unit.domainID)) this.getCiv(unit.domainID).removeUnit(unit);
+    else if (isCityDomain(unit.domainID)) this.getCity(unit.domainID).removeUnit(unit);
     this.updates.push(() => ['unitKilled', [ unit.coords, unit ]]);
     this.map.getTileOrThrow(unit.coords).setUnit(undefined);
     // TODO: make this more intelligent
-    if (unit.civID !== undefined) this.updateCivTileVisibility(unit.civID)
-    this.updates.push((civID) => ['setMap', [this.map.getCivMap(civID)]]);
+    if (isCivDomain(unit.domainID)) this.updateCivTileVisibility(unit.domainID);
+    this.updates.push((leader) => ['setMap', [this.map.getLeaderMap(leader)]]);
   }
 
   rangedCombat(attacker: Unit, defender: Unit): void {

--- a/server/src/methods.ts
+++ b/server/src/methods.ts
@@ -27,8 +27,8 @@ const sendTo = (ws: WebSocketManager, msg: { [key: string]: unknown }) => {
 
 export const games: { [gameID: number] : Game } = {};
 (async () => {
-  const game = await Game.load('singleplayer test')
-  games[newID()] = game;
+  // const game = await Game.load('singleplayer test')
+  // games[newID()] = game;
 })()
 
 function newID(): number {
@@ -50,6 +50,21 @@ const createGame = (username: string, playerCount: number, mapOptions: MapOption
     }
   ]);
 };
+
+(async () => {
+  createGame(
+    'system',
+    1,
+    {
+      width: 100,
+      height: 100,
+    },
+    {
+      seed: null,
+      gameName: 'random seed test',
+    }
+  )
+})
 
 export const getConnData = (ws: WebSocketManager): ConnectionData => {
   const connIndex = connections.indexOf(ws);
@@ -228,9 +243,10 @@ const methods: {
     });
   },
 
-  setLeader: (ws: WebSocketManager, leaderID: number) => {
+  // TODO - rename to selectCiv
+  setLeader: (ws: WebSocketManager, civTemplateID: number) => {
     const [game, player] = getGameInfo(ws);
-    game.setLeader(player, leaderID);
+    game.selectCiv(player, civTemplateID);
   },
 
   ready: (ws: WebSocketManager, state: boolean) => {

--- a/server/src/utils/error.ts
+++ b/server/src/utils/error.ts
@@ -1,7 +1,7 @@
 const DEBUG_MODE = false;
 
 class BaseError extends Error {
-  constructor(msg: string) {
+  constructor(msg?: string) {
     super(msg);
     this.name = this.constructor.name;
     console.error(DEBUG_MODE ? this.stack : `${this.name}: ${this.message}`);
@@ -9,6 +9,10 @@ class BaseError extends Error {
 }
 
 export class InternalServerError extends BaseError {}
+export class BugFixError extends InternalServerError {}
+
+export class IllegalCmdError extends BaseError {}
+export class GameNotStartedError extends IllegalCmdError {}
 
 export class MapError extends BaseError {}
 export class GenerationFailed extends MapError {}

--- a/server/src/utils/error.ts
+++ b/server/src/utils/error.ts
@@ -8,12 +8,15 @@ class BaseError extends Error {
   }
 }
 
+export class InternalServerError extends BaseError {}
+
 export class MapError extends BaseError {}
 export class GenerationFailed extends MapError {}
 export class NoStartLocation extends MapError {}
 
 export class ValueError extends BaseError {}
 export class InvalidCoordsError extends ValueError {}
+export class IllegalCoordsError extends ValueError {}
 
 export class FrontendError extends BaseError {
   errName: string;

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -9,10 +9,6 @@ export interface EventMsg {
   error?: Event[];
 }
 
-export interface PlayerData {
-  civID: number;
-}
-
 export const mod = (a: number, b: number): number => {
   if (a >= 0) {
     return a % b;


### PR DESCRIPTION
Most of the dirty work of #183 is done.

Essentially, the Leader and Civilization classes have been swapped, taking each other's roles in *most* cases.

Leaders:
- Own any number of Domains (which can be either Civilizations or Cities)
- Keep track of turns.

Domains (Civs *and* Cities):
- Control a list of units.
- Have one Leader, or null.

Civilizations:
- Have a name and a jersey color.
- Have unique starting knowledges.

The DomainID type was added, which contains information about both the type of domain as well as a numeric ID (`subID`) for the domain. The `subID` is not globally unique, it's just unique within the specific DomainType.